### PR TITLE
Error in generator.yml skeleton

### DIFF
--- a/Resources/skeleton/bundle/generator.yml
+++ b/Resources/skeleton/bundle/generator.yml
@@ -17,6 +17,7 @@ builders:
         edit: ~
         delete: ~
   filters:
+    params:
       display: [ ]
   new:
     params:


### PR DESCRIPTION
Hi,

I get an error when I generate a new AdminBundle:
Item "display" for "" does not exist in "ListBuilderAction.php.twig" at line 38

I get this error when I do somethin like clear cache.

Not sure if it's a bug but I see in generator.yml that builders list, new and edit have a child "params" but not filters. Shouldn't have filters also a "params" child ?
