### PR TITLE
typo missing "/" in vendor/bundles/Admingenerator/GeneratorBundle

### DIFF
--- a/installation.markdown
+++ b/installation.markdown
@@ -23,7 +23,7 @@ This is the installation recommanded if you want to try the bundle in 2 minutes
 ## On a symfony2 project ##
 
 {% highlight bash %}
-git submodule add git://github.com/cedriclombardot/AdmingeneratorGeneratorBundle.git vendor/bundles/AdmingeneratorGeneratorBundle
+git submodule add git://github.com/cedriclombardot/AdmingeneratorGeneratorBundle.git vendor/bundles/Admingenerator/GeneratorBundle
 {% endhighlight %}
 
 Register it in the `autoload.php` file:


### PR DESCRIPTION
prevent wrong vendors folder when use git submodule add
