### PR TITLE
Move the prefix at the end of the namespace

### DIFF
--- a/Resources/skeleton/bundle/DefaultController.php
+++ b/Resources/skeleton/bundle/DefaultController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace {{ namespace }}Controller{{ prefix ? "\\" ~ prefix : "" }};
+namespace {{ namespace }}\Controller{{ prefix ? "\\" ~ prefix : "" }};
 
 use Admingenerated\{{ bundle }}\Base{{ prefix }}Controller\{{ action }}Controller as Base{{ action }}Controller;
 


### PR DESCRIPTION
As prefixed controller files are saved in `Acme/MyBundle/Controller/MyPrefix`, the namespace must be `Acme\MyBundle\Controller\MyPrefix`.

The namespace actualy generated is `Acme\MyBundle\MyPrefix\Controller` and the autoloader fail to load the controller.
