### PR TITLE
Allow HTML in messages (success, error)

### DIFF
--- a/Resources/views/base_admin.html.twig
+++ b/Resources/views/base_admin.html.twig
@@ -51,12 +51,12 @@
             {% block flashes %}
                 {% if app.session.flash('success') %}
                     <div class="notification_box success">
-                        {{ app.session.flash('success') }}
+                        {{ app.session.flash('success')|raw }}
                     </div>
                 {% endif %}
                 {% if app.session.flash('error') %}
                     <div class="notification_box error">
-                        {{ app.session.flash('error') }}
+                        {{ app.session.flash('error')|raw }}
                     </div>
                 {% endif %}
             {% endblock %}

--- a/Resources/views/base_admin_assetic_less.html.twig
+++ b/Resources/views/base_admin_assetic_less.html.twig
@@ -44,12 +44,12 @@
             {% block flashes %}
                 {% if app.session.flash('success') %}
                     <div class="notification_box success">
-                        {{ app.session.flash('success') }}
+                        {{ app.session.flash('success')|raw }}
                     </div>
                 {% endif %}
                 {% if app.session.flash('error') %}
                     <div class="notification_box error">
-                        {{ app.session.flash('error') }}
+                        {{ app.session.flash('error')|raw }}
                     </div>
                 {% endif %}
             {% endblock %}


### PR DESCRIPTION
Use case: highlight a special information

```
Thanks for registering a new app, your API key is <b>AVEFEFEG</b>.
```
