### PR TITLE
use fieldnames instead of columnnames when working with orm-models

### DIFF
--- a/Builder/Admin/BaseBuilder.php
+++ b/Builder/Admin/BaseBuilder.php
@@ -99,7 +99,7 @@ class BaseBuilder extends GenericBaseBuilder
         $display = $this->getVariable('display');
 
         if (null == $display || 0 == sizeof($display)) {
-           return $this->getAllColumns();
+           return $this->getAllFields();
         }
 
         if (isset($display[0])) {
@@ -127,9 +127,9 @@ class BaseBuilder extends GenericBaseBuilder
      *
      * @return array
      */
-    protected function getAllColumns()
+    protected function getAllFields()
     {
-        return $this->getFieldGuesser()->getAllColumns($this->getVariable('model'));
+        return $this->getFieldGuesser()->getAllFields($this->getVariable('model'));
     }
 
     /**
@@ -143,7 +143,7 @@ class BaseBuilder extends GenericBaseBuilder
         $display = $this->getVariable('display');
 
         if (null == $display || 0 == sizeof($display)) {
-           $display = $this->getAllColumns();
+           $display = $this->getAllFields();
         }
 
         if (isset($display[0])) {

--- a/Builder/Admin/FiltersBuilder.php
+++ b/Builder/Admin/FiltersBuilder.php
@@ -32,7 +32,7 @@ class FiltersBuilder extends BaseBuilder
         $display = $this->getVariable('display');
 
         if (null == $display) {
-           $display = $this->getAllColumns();
+           $display = $this->getAllFields();
         }
 
         foreach ($display as $columnName) {

--- a/Builder/Admin/ListBuilder.php
+++ b/Builder/Admin/ListBuilder.php
@@ -59,7 +59,7 @@ class ListBuilder extends BaseBuilder
         $filters = $this->getFilters();
 
         if (!isset($filters['display']) || is_null($filters['display'])) {
-            $filters['display'] = $this->getAllColumns();
+            $filters['display'] = $this->getAllFields();
         }
 
         foreach ($filters['display'] as $columnName) {

--- a/Guesser/DoctrineODMFieldGuesser.php
+++ b/Guesser/DoctrineODMFieldGuesser.php
@@ -38,7 +38,7 @@ class DoctrineODMFieldGuesser
         return $this->metadata[$class];
     }
 
-    public function getAllColumns($class)
+    public function getAllFields($class)
     {
         $fields = array();
 

--- a/Guesser/DoctrineORMFieldGuesser.php
+++ b/Guesser/DoctrineORMFieldGuesser.php
@@ -38,14 +38,9 @@ class DoctrineORMFieldGuesser
         return $this->metadata[self::$current_class];
     }
 
-    public function getAllColumns($class)
+    public function getAllFields($class)
     {
-        $fieldNames = array();
-        $metadata = $this->getMetadatas($class);
-        foreach ($metadata->getColumnNames() as $columnName) {
-            $fieldNames[] = $metadata->getFieldName($columnName);
-        }
-        return $fieldNames;
+        return $this->getMetadatas($class)->getFieldNames();
     }
 
     public function getDbType($class, $fieldName)

--- a/Guesser/PropelORMFieldGuesser.php
+++ b/Guesser/PropelORMFieldGuesser.php
@@ -28,7 +28,7 @@ class PropelORMFieldGuesser
         return $this->getTable(self::$current_class);
     }
 
-    public function getAllColumns($class)
+    public function getAllFields($class)
     {
         $return = array();
 


### PR DESCRIPTION
... field names because getDbType() checks for fieldnames. When it comes to naming, this is not a very solid solution, but it should demonstrate the problem.
