### PR TITLE
Fixed output of routing in generate-admin command

### DIFF
--- a/Command/GenerateAdminAdminCommand.php
+++ b/Command/GenerateAdminAdminCommand.php
@@ -154,7 +154,7 @@ EOT
         try {
             $ret = $auto ? $routing->addResource($bundle, 'admingenerator') : false;
             if (!$ret) {
-                $help = sprintf("        <comment>resource: \"@%s/Resources/Controller/%s/\"</comment>\n        <comment>type:     admingenerator</comment>", $bundle, ucfirst($input->getOption('prefix')));
+                $help = sprintf("        <comment>resource: \"@%s/Resources/Controller/%s/\"</comment>\n        <comment>type:     admingenerator</comment>\n", $bundle, ucfirst($input->getOption('prefix')));
                 $help .= "        <comment>prefix:   /</comment>\n";
 
                 return array(


### PR DESCRIPTION
Fixed small line break that when you say no to auto-update routing would cause it to output improperly.
