### PR TITLE
Error in getEchoIf and getEchoElseIf

### DIFF
--- a/Twig/Extension/EchoExtension.php
+++ b/Twig/Extension/EchoExtension.php
@@ -155,11 +155,17 @@ class EchoExtension extends \Twig_Extension
 
     public function getEchoIf($condition)
     {
+        if( is_bool( $condition ) ) {
+            $condition = intval( $condition );
+        }
         return str_replace('%%condition%%', $condition, '{% if %%condition%% %}');
     }
 
     public function getEchoElseIf($condition)
     {
+        if( is_bool( $condition ) ) {
+            $condition = intval( $condition );
+        }
         return str_replace('%%condition%%', $condition, '{% elseif %%condition%% %}');
     }
 


### PR DESCRIPTION
Problem shows when column is virtual and not sortable. Then column.isSortable was returning false and str_replace used in those function is interpreting false as null. So the code looked like:

``` twig
{% if  %}sortable
```

Casting boolean to integer should fix this problem
