### PR TITLE
Added missing setLabel

### DIFF
--- a/Generator/Action.php
+++ b/Generator/Action.php
@@ -30,6 +30,11 @@ class Action
         return $this->name;
     }
 
+    public function setLabel($name)
+    {
+        $this->name = $name;
+    }
+
     public function getLabel()
     {
         return $this->humanize($this->getName());


### PR DESCRIPTION
According to documentation, I can change the label of action:
http://symfony2admingenerator.org/documentation/list.html#actions

But when I use "label" parameter I receive:
`An exception has been thrown during the rendering of a template ("Warning: call_user_func_array() expects parameter 1 to be a valid callback, class 'Admingenerator\GeneratorBundle\Generator\Action' does not have a method 'setLabel'`
