### PR TITLE
Added missing setLabel

### DIFF
--- a/Generator/Action.php
+++ b/Generator/Action.php
@@ -14,6 +14,8 @@ class Action
 {
     protected $name;
 
+    protected $label;
+
     protected $route;
 
     protected $confirm_message;
@@ -30,8 +32,16 @@ class Action
         return $this->name;
     }
 
+    public function setLabel($label)
+    {
+        $this->label = $label;
+    }
+
     public function getLabel()
     {
+        if ( isset ($this->label) ) {
+            return $this->label;
+        }
         return $this->humanize($this->getName());
     }
 


### PR DESCRIPTION
According to documentation, I can change the label of action:
http://symfony2admingenerator.org/documentation/list.html#actions

But when I use "label" parameter I receive:
`An exception has been thrown during the rendering of a template ("Warning: call_user_func_array() expects
parameter 1 to be a valid callback, class 'Admingenerator\GeneratorBundle\Generator\Action' does not have a 
method 'setLabel'`
