### PR TITLE
In the command admin:setup seems to be a little bug.

### DIFF
--- a/Command/SetupOrUpgradeCommand.php
+++ b/Command/SetupOrUpgradeCommand.php
@@ -117,7 +117,7 @@ EOT
             '<comment>    expressions</comment>: <info>true</info>',
         ));
 
-         if ('yes' == $useAssetic) {
+         if (isset($useAssetic) && 'yes' == $useAssetic) {
               $output->writeln(array(
                 '',
                 'Check your <comment>assetic</comment> configuration ',


### PR DESCRIPTION
In the command admin:setup seems to be a little bug.
When I choose "own" as skin an error message comes up:
[ErrorException]
  Notice: Undefined variable: useAssetic in /vendor/bundles/Admingenerator/GeneratorBundle/Command/SetupOrUpgradeCommand.php line 120  

I tried to fix it in line 120 but you'll see the changes anyways, I guess ;)

Bye,
Tobias

P.S. Symfony2 with bundles makes programmers life a lot easier :D
