### PR TITLE
Fixed some issues I found when using MongoDB with 2.0 branch

### DIFF
--- a/Form/Type/DoctrineODMDoubleListType.php
+++ b/Form/Type/DoctrineODMDoubleListType.php
@@ -2,7 +2,7 @@
 
 namespace Admingenerator\GeneratorBundle\Form\Type;
 
-use Doctrine\Bundle\MongoDBBundle\Form\Type\DocumentType;
+use Symfony\Bundle\DoctrineMongoDBBundle\Form\Type\DocumentType;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\FormInterface;
 

--- a/Guesser/DoctrineODMFieldGuesser.php
+++ b/Guesser/DoctrineODMFieldGuesser.php
@@ -156,13 +156,13 @@ class DoctrineODMFieldGuesser
         if ('document' == $dbType) {
             $mapping = $this->getMetadatas()->getFieldMapping($columnName);
 
-            return array( 'class' => $mapping['targetDocument'], 'multiple' => false);
+            return array('class' => $mapping['targetDocument'], 'multiple' => false);
         }
 
         if ('collection' == $dbType) {
             $mapping = $this->getMetadatas()->getFieldMapping($columnName);
 
-            return array('class' => $mapping['targetDocument']);
+            return array('type' => $mapping['targetDocument']);
         }
 
         if ('collection' == $formType) {


### PR DESCRIPTION
- Changed the namespace used for MongoDBBundle to what the Symfony manual says it should use (http://symfony.com/doc/current/bundles/DoctrineMongoDBBundle/index.html).
- The 'class' option in CollectionType is not used and triggers an error: "Option 'class' desn't exist"
