### PR TITLE
Symfony 2.1 Compatibility

### DIFF
--- a/Form/Type/DateRangeType.php
+++ b/Form/Type/DateRangeType.php
@@ -34,34 +34,33 @@ class DateRangeType extends AbstractType
                ->add('to', new DateType(), $options['to']);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getParent(array $options)
     {
         return 'form';
     }
 
-    public function getDefaultOptions(array $options)
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultOptions()
     {
-        $defaultOptions = array(
+        $years = range(date('Y'), date('Y') - 120);
+
+        return array(
             'format'            => null,
-            'years'             => range(date('Y'), date('Y') - 120),
-            'to'                => null,
-            'from'              => null,
+            'years'             => $years,
+            'to'                => array('years' => $years, 'widget' => 'choice'),
+            'from'              => array('years' => $years, 'widget' => 'choice'),
             'widget'            => 'choice',
         );
-
-        $options = array_replace($defaultOptions, $options);
-
-        if (is_null($defaultOptions['to'])) {
-            $defaultOptions['to'] = array('years' => $defaultOptions['years'], 'widget' => $defaultOptions['widget']);
-        }
-
-        if (is_null($defaultOptions['from'])) {
-            $defaultOptions['from'] = array('years' => $defaultOptions['years'], 'widget' => $defaultOptions['widget']);
-        }
-
-        return $defaultOptions;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getName()
     {
         return 'date_range';

--- a/Form/Type/DoctrineDoubleListType.php
+++ b/Form/Type/DoctrineDoubleListType.php
@@ -43,12 +43,11 @@ class DoctrineDoubleListType extends EntityType
     /**
      * {@inheritdoc}
      */
-    public function getDefaultOptions(array $options)
+    public function getDefaultOptions()
     {
-        $options = parent::getDefaultOptions($options);
-        $options['multiple'] = true;
-
-        return $options;
+        return array_merge(parent::getDefaultOptions(), array(
+            'multiple'  => true,
+        ));
     }
 
     /**

--- a/Form/Type/DoctrineODMDoubleListType.php
+++ b/Form/Type/DoctrineODMDoubleListType.php
@@ -43,12 +43,11 @@ class DoctrineODMDoubleListType extends DocumentType
     /**
      * {@inheritdoc}
      */
-    public function getDefaultOptions(array $options)
+    public function getDefaultOptions()
     {
-        $options = parent::getDefaultOptions($options);
-        $options['multiple'] = true;
-
-        return $options;
+        return array_merge(parent::getDefaultOptions(), array(
+            'multiple'  => true,
+        ));
     }
 
     /**

--- a/Form/Type/PropelDoubleListType.php
+++ b/Form/Type/PropelDoubleListType.php
@@ -43,12 +43,11 @@ class PropelDoubleListType extends ModelType
     /**
      * {@inheritdoc}
      */
-    public function getDefaultOptions(array $options)
+    public function getDefaultOptions()
     {
-        $options = parent::getDefaultOptions($options);
-        $options['multiple'] = true;
-
-        return $options;
+        return array_merge(parent::getDefaultOptions(), array(
+            'multiple'  => true,
+        ));
     }
 
     /**


### PR DESCRIPTION
Hi,

Symfony 2.1 FormTypeInterface have changed. From now, the getDefaultOptions dont need the $options parameter.
