### PR TITLE
Update PagerFanta required version to be set to Symfony2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "symfony/symfony": "2.0.*",
         "cedriclombardot/twig-generator": "dev-master",
         "knplabs/knp-menu-bundle": "dev-master",
-        "white-october/pagerfanta-bundle": "dev-master"
+        "white-october/pagerfanta-bundle": "dev-symfony2.0"
     },
     "target-dir": "Admingenerator/GeneratorBundle",
     "autoload": {


### PR DESCRIPTION
dev-master version do not include management of empty route parameter that are handled in dev-symfony2.0  version
