### PR TITLE
Fix: buildForm() and buildView signatures

### DIFF
--- a/Form/Type/DateRangeType.php
+++ b/Form/Type/DateRangeType.php
@@ -5,9 +5,7 @@ namespace Admingenerator\GeneratorBundle\Form\Type;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\FormBuilder;
-use Symfony\Component\Form\FormView;
-use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormBuilderInterface;
 
 
 class DateRangeType extends AbstractType
@@ -16,7 +14,7 @@ class DateRangeType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilder $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options)
     {
          unset($options['years']);
 
@@ -37,7 +35,7 @@ class DateRangeType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent(array $options)
+    public function getParent()
     {
         return 'form';
     }

--- a/Form/Type/DoctrineDoubleListType.php
+++ b/Form/Type/DoctrineDoubleListType.php
@@ -3,7 +3,7 @@
 namespace Admingenerator\GeneratorBundle\Form\Type;
 
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
-use Symfony\Component\Form\FormView;
+use Symfony\Component\Form\FormViewInterface;
 use Symfony\Component\Form\FormInterface;
 
 class DoctrineDoubleListType extends EntityType
@@ -11,7 +11,7 @@ class DoctrineDoubleListType extends EntityType
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form)
+    public function buildView(FormViewInterface $view, FormInterface $form, array $options)
     {
         $choiceList = $form->getAttribute('choice_list');
 

--- a/Form/Type/DoctrineODMDoubleListType.php
+++ b/Form/Type/DoctrineODMDoubleListType.php
@@ -3,7 +3,7 @@
 namespace Admingenerator\GeneratorBundle\Form\Type;
 
 use Doctrine\Bundle\MongoDBBundle\Form\Type\DocumentType;
-use Symfony\Component\Form\FormView;
+use Symfony\Component\Form\FormViewInterface;
 use Symfony\Component\Form\FormInterface;
 
 class DoctrineODMDoubleListType extends DocumentType
@@ -11,7 +11,7 @@ class DoctrineODMDoubleListType extends DocumentType
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form)
+    public function buildView(FormViewInterface $view, FormInterface $form, array $options)
     {
         $choiceList = $form->getAttribute('choice_list');
 

--- a/Form/Type/PropelDoubleListType.php
+++ b/Form/Type/PropelDoubleListType.php
@@ -3,7 +3,7 @@
 namespace Admingenerator\GeneratorBundle\Form\Type;
 
 use Symfony\Bridge\Propel1\Form\Type\ModelType;
-use Symfony\Component\Form\FormView;
+use Symfony\Component\Form\FormViewInterface;
 use Symfony\Component\Form\FormInterface;
 
 class PropelDoubleListType extends ModelType
@@ -11,7 +11,7 @@ class PropelDoubleListType extends ModelType
     /**
      * {@inheritdoc}
      */
-    public function buildView(FormView $view, FormInterface $form)
+    public function buildView(FormViewInterface $view, FormInterface $form, array $options)
     {
         $choiceList = $form->getAttribute('choice_list');
 


### PR DESCRIPTION
Their signatures changed with the recent modifications done in symfony's
form component.

I fixed the bundle's code, but I couldn't fix the _FiltersType_ classes as I
don't know where they are generated.
Can you explain me where theses classes are handled so that I can fix them?
