### PR TITLE
Shortcut submit action in new/edit form

### DIFF
--- a/Resources/public/css/forms.sass
+++ b/Resources/public/css/forms.sass
@@ -94,7 +94,24 @@ fieldset.form_block
       background: url(/bundles/admingeneratorgenerator/images/submit_background_hover.png) repeat-x
       cursor: pointer
       cursor: hand
-      
+form 
+  .actions
+    li 
+      float: left
+      padding-right: 10px 
+    .submit_button
+      background: url(/bundles/admingeneratorgenerator/images/submit_background.png) repeat-x
+      height: 20px
+      border: 1px solid #D2D2D2
+      color: #2A363B
+      padding-left: 20px
+      padding-right: 20px
+      +buttons_border
+      outline: none
+      &:hover
+        background: url(/bundles/admingeneratorgenerator/images/submit_background_hover.png) repeat-x
+        cursor: pointer
+        cursor: hand      
 .filters
   fieldset.form_block 
     .form_row

--- a/Resources/templates/CommonAdmin/EditAction/update.php.twig
+++ b/Resources/templates/CommonAdmin/EditAction/update.php.twig
@@ -25,6 +25,12 @@
 
                 $this->get('session')->setFlash('success', $this->get('translator')->trans("{{ messages.success is defined ? messages.success : "object.saved.success" }}", array(), 'Admingenerator') );
 
+                $request = $this->getRequest()->request;
+                if($request->has('_save_and_add')) {
+                    return new RedirectResponse($this->generateUrl("{{ builder.routePrefixWithSubfolder }}_{{ bundle_name }}{{ builder.BaseGeneratorName ? "_" ~ builder.BaseGeneratorName : "" }}_new"));
+                } elseif($request->has('_save_and_list')) {
+                    return new RedirectResponse($this->generateUrl("{{ builder.routePrefixWithSubfolder }}_{{ bundle_name }}{{ builder.BaseGeneratorName ? "_" ~ builder.BaseGeneratorName : "" }}_list"));
+                }
                 return new RedirectResponse($this->generateUrl("{{ builder.routePrefixWithSubfolder }}_{{ bundle_name }}{{ builder.BaseGeneratorName ? "_" ~ builder.BaseGeneratorName : "" }}_edit", array('pk' => $pk) ));
             } catch (\Exception $e) {
                 $this->get('session')->setFlash('error',  $this->get('translator')->trans("{{ messages.error is defined ? messages.error : "object.saved.error" }}", array(), 'Admingenerator') );

--- a/Resources/templates/CommonAdmin/EditTemplate/form.php.twig
+++ b/Resources/templates/CommonAdmin/EditTemplate/form.php.twig
@@ -24,7 +24,13 @@
         {{ echo_block("form_buttons") }}
         <ul class="actions">
             <li>
-                 <input type="submit" class="submit_button" value="{{ echo_trans('form.btn_save') }}" />
+                 <input type="submit" name="_save" class="submit_button" value="{{ echo_trans('form.btn_save') }}" />
+            </li>
+            <li>
+                 <input type="submit" name="_save_and_add" class="submit_button" value="{{ echo_trans('form.btn_save_and_add') }}" />
+            </li>
+            <li>
+                 <input type="submit" name="_save_and_list" class="submit_button" value="{{ echo_trans('form.btn_save_and_list') }}" />
             </li>
         </ul>
         {{ echo_endblock() }}

--- a/Resources/translations/Admingenerator.de.yml
+++ b/Resources/translations/Admingenerator.de.yml
@@ -23,6 +23,8 @@ object.deleted.error: Der Eintrag kann nicht gelöscht werden
 
 # Form
 form.btn_save: Speichern
+form.btn_save_and_add: Speichern und Hinzufügen
+form.btn_save_and_list: Speichern und Auflisten
 form.type_collection.add: Hinzufügen
 
 # Actions

--- a/Resources/translations/Admingenerator.en.yml
+++ b/Resources/translations/Admingenerator.en.yml
@@ -23,6 +23,8 @@ object.deleted.error: The record can't be deleted
 
 # Form
 form.btn_save: Save
+form.btn_save_and_add: Save and Add
+form.btn_save_and_list: Save and List
 form.type_collection.add: Add
 form.delete.confirm: Are you sure ?
 

--- a/Resources/translations/Admingenerator.es.yml
+++ b/Resources/translations/Admingenerator.es.yml
@@ -23,6 +23,8 @@ object.deleted.error: The record can't be deleted
 
 # Form
 form.btn_save: Guardar
+form.btn_save_and_add: Guardar y Añadir
+form.btn_save_and_list: Guardar y Listar
 form.type_collection.add: Añadir
 
 # Actions

--- a/Resources/translations/Admingenerator.fr.yml
+++ b/Resources/translations/Admingenerator.fr.yml
@@ -23,6 +23,8 @@ object.deleted.error: L'enregistrement n'a pas pu être supprimé
 
 # Form
 form.btn_save: Enregistrer
+form.btn_save_and_add: Enregistrer et Ajouter
+form.btn_save_and_list: Enregistrer et Lister
 form.type_collection.add: Ajouter
 form.delete.confirm: Etes-vous sur de vouloir supprimer cet élement ?
 

--- a/Resources/translations/Admingenerator.pl.yml
+++ b/Resources/translations/Admingenerator.pl.yml
@@ -23,6 +23,8 @@ object.deleted.error: Nie można usunąć tego wpisu
 
 # Form
 form.btn_save: Zapisz
+form.btn_save_and_add: Zapisz i Dodaj
+form.btn_save_and_list: Zapisz i Lista
 form.type_collection.add: Dodaj
 
 # Actions

--- a/Resources/translations/Admingenerator.ru.yml
+++ b/Resources/translations/Admingenerator.ru.yml
@@ -23,6 +23,8 @@ object.deleted.error: Материал не может быть удален
 
 # Form
 form.btn_save: Сохранить
+form.btn_save_and_add: Сохранить и Добавить
+form.btn_save_and_list: Сохранить и Список
 form.type_collection.add: Добавить
 form.delete.confirm: Ви действительно хотите удалить этот элемент ?
 

--- a/Resources/translations/Admingenerator.sl.yml
+++ b/Resources/translations/Admingenerator.sl.yml
@@ -23,6 +23,8 @@ object.deleted.error: Predmet ni bil izbrisan.
 
 # Form
 form.btn_save: Shrani
+form.btn_save_and_add:  Shrani in Dodaj
+form.btn_save_and_list: Shrani  in Seznam
 form.type_collection.add: Dodaj
 
 # Actions

--- a/Resources/translations/Admingenerator.uk.yml
+++ b/Resources/translations/Admingenerator.uk.yml
@@ -23,6 +23,8 @@ object.deleted.error: Запис не може бути видалений
 
 # Form
 form.btn_save: Зберегти
+form.btn_save_and_add: Зберегти й Додати
+form.btn_save_and_list: Зберегти й Список
 form.type_collection.add: Додати
 form.delete.confirm: Ви дійсно хочете видалити цей елемент ?
 


### PR DESCRIPTION
Hi,
just add 2 shortcut submit action in new/edit form
- add a "Save and Add" action for repeated creates without returning to list each time 
- add a "Save and List

those ideas are proposed in issue #91
