### PR TITLE
Translatable field type for Propel i18n columns

### DIFF
--- a/Form/Type/TranslationCollectionType.php
+++ b/Form/Type/TranslationCollectionType.php
@@ -1,0 +1,121 @@
+<?php
+namespace Admingenerator\GeneratorBundle\Form\Type;
+
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\Form\Event\DataEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+/**
+ * form type for i18n-columns in propel
+ *
+ * @author Patrick Kaufmann
+ */
+class TranslationCollectionType extends CollectionType implements ContainerAwareInterface
+{
+
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function __construct($container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $languages = $options['languages'];
+        $i18nClass = $options['i18n_class'];
+
+        $options['options']['data_class'] = $i18nClass;
+        $options['options']['columns'] = $options['columns'];
+
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, function(DataEvent $event) use ($builder, $languages, $i18nClass) {
+            $form = $event->getForm();
+            $data = $event->getData();
+
+            if($data == null)
+            {
+                return;
+            }
+
+            //get the class name of the i18nClass
+            $temp = explode('\\', $i18nClass);
+            $dataClass = end($temp);
+
+            $rootData = $form->getRoot()->getData();
+
+            //add a database row for every needed language
+            foreach($languages as $lang)
+            {
+                $found = false;
+
+                foreach($data as $i18n)
+                {
+                    if($i18n->getLocale() == $lang)
+                    {
+                        $found = true;
+                        break;
+                    }
+                }
+
+                if(!$found)
+                {
+                    $newTranslation = new $i18nClass();
+                    $newTranslation->setLocale($lang);
+
+                    $addFunction = 'add'.$dataClass;
+                    $rootData->$addFunction($newTranslation);
+                }
+            }
+        });
+
+        parent::buildForm($builder, $options);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'translatable_collection';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        parent::setDefaultOptions($resolver);
+        $resolver->setDefaults(array(
+            'languages' => array(),
+            'i18n_class' => '',
+            'attr' => array('class' => 'type_collection'),
+            'columns' => array(),
+            'type' => 'translation_type',
+            'allow_add' => false,
+            'allow_delete' => false,
+            'languages' => $this->container->getParameter('languages')
+        ));
+    }
+
+    /**
+     * Sets the Container.
+     *
+     * @param ContainerInterface $container A ContainerInterface instance
+     *
+     * @api
+     */
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+}

--- a/Form/Type/TranslationType.php
+++ b/Form/Type/TranslationType.php
@@ -1,0 +1,80 @@
+<?php
+namespace Admingenerator\GeneratorBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Event\DataEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\FormBuilderInterface;
+
+/**
+ * @author Patrick Kaufmann
+ */
+class TranslationType extends AbstractType
+{
+    /**
+      * {@inheritdoc}
+      */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $columns = $options['columns'];
+        $dataClass = $options['data_class'];
+
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, function(DataEvent $event) use ($builder, $columns, $dataClass) {
+            $form = $event->getForm();
+            $data = $event->getData();
+            if(!$data instanceof $dataClass)
+            {
+                return;
+            }
+
+            //loop over all columns and add the input
+            foreach($columns as $column => $options)
+            {
+                if($options == null) $options = array();
+
+                $type = 'text';
+                if(array_key_exists('type', $options))
+                {
+                    $type = $options['type'];
+                }
+                $label = $column;
+                if(array_key_exists('label', $options))
+                {
+                    $label = $options['label'];
+                }
+
+                $customOptions = array();
+                if(array_key_exists('options', $options))
+                {
+                    $customOptions = $options['options'];
+                }
+                $options = array(
+                    'label' => $label.' '.strtoupper($data->getLocale())
+                );
+
+                $options = array_merge($options, $customOptions);
+
+                $form->add($builder->getFormFactory()->createNamed($column, $type, null, $options));
+            }
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'translation_type';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultOptions()
+    {
+        return array(
+            'columns' => array(),
+            'language' => ''
+        );
+    }
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -61,6 +61,17 @@
             <tag name="form.type" alias="double_list" />
         </service>
 
+        <service id="form.type.translatable_collection" class="Admingenerator\GeneratorBundle\Form\Type\TranslationCollectionType">
+            <tag name="form.type" alias="translatable_collection" />
+            <call method="setContainer">
+                <argument type="service" id="service_container" />
+            </call>
+        </service>
+
+        <service id="form.type.translation_type" class="Admingenerator\GeneratorBundle\Form\Type\TranslationType">
+            <tag name="form.type" alias="translation_type" />
+        </service>
+
         <!-- Warmup -->
         <service id="admingenerator.finder" class="%admingenerator.finder.class%" public="false">
             <argument type="service" id="kernel" />


### PR DESCRIPTION
Added a translatable field type for I18n columns in Propel.

Can be used as shown in this [gist](https://gist.github.com/3143729).
