### PR TITLE
Collection new_label translation with i18n_catalogue

### DIFF
--- a/Resources/templates/CommonAdmin/EditTemplate/Type/collection.php.twig
+++ b/Resources/templates/CommonAdmin/EditTemplate/Type/collection.php.twig
@@ -21,7 +21,7 @@
 
         $('#type_collection_{{ field }} .new').click(function() {
            var prototype = $('#{{ builder.YamlKey }}_{{ builder.ModelClass|lower }}_{{ field }}').data('prototype');
-           prototype = prototype.replace(/__name__label__/g, "{{ builder.Columns[field].extras.new_label is defined ? builder.Columns[field].extras.new_label : 'type_collection_' ~ field ~ '_nextId' }}");
+           prototype = prototype.replace(/__name__label__/g, "{{ echo_trans(builder.Columns[field].extras.new_label is defined ? builder.Columns[field].extras.new_label : 'type_collection_' ~ field ~ '_nextId', i18n_catalog is defined ? i18n_catalog : "Admin" ) }}");
            prototype = prototype.replace(/__name__/g, type_collection_{{ field }}_nextId);
            type_collection_{{ field }}_nextId++;
            $('#{{ builder.YamlKey }}_{{ builder.ModelClass|lower }}_{{ field }}').append(prototype);


### PR DESCRIPTION
Allows this:

``` yaml
generator: admingenerator.generator.doctrine
params:
  model: Avocode\TestBundle\Entity\Album
  namespace_prefix: Avocode
  bundle_name: TestBundle
  i18n_catalog: AvocodeTestBundle
  fields:
    songs:
      formType: collection
      extras:
        new_label: album.songs.new.label   #will look for album.songs.new.label in AvocodeTestBundle.xx.yml
      addFormOptions:
        type: \Avocode\TestBundle\Form\Type\EmbedsongType
        allow_add: true
        allow_delete: true
        by_reference: false
```
