### PR TITLE
Update Resources/templates/CommonAdmin/ListTemplate/actions.php.twig

### DIFF
--- a/Resources/templates/CommonAdmin/ListTemplate/actions.php.twig
+++ b/Resources/templates/CommonAdmin/ListTemplate/actions.php.twig
@@ -8,7 +8,7 @@
             {% endif %}
 
             <li><a class="{{ action.name }}" href="{{ echo_path((action.route ? action.route : builder.routePrefixWithSubfolder ~ '_' ~ bundle_name ~ ( builder.BaseGeneratorName ? "_" ~ builder.BaseGeneratorName : "" ) ~ '_' ~ action.name)) }}"
-            {%- if action.confirm %}onclick='return confirm("{{ action.confirm }}")'{% endif %}>{{ echo_trans(action.label) }}</a></li>
+            {%- if action.confirm %}onclick='return confirm("{{ echo_trans(action.confirm, i18n_catalog is defined ? i18n_catalog : "Admin") }}")'{% endif %}>{{ echo_trans(action.confirm, i18n_catalog is defined ? i18n_catalog : "Admin") }}</a></li>
 
                {% if action.credentials or builder.generator.getFromYaml('builders.' ~ action.name ~ '.params.credentials') %}
                 {{ echo_endif () }}


### PR DESCRIPTION
Since you may add custom actions in your generator - their translations should reside in custom i18n_catalogue (or default "Admin"), not in common catalogue "Admingenerator".

Also, introduced translation of action.confirm message.
