### PR TITLE
Catch all exceptions on Delete action

### DIFF
--- a/Resources/templates/CommonAdmin/DeleteAction/index.php.twig
+++ b/Resources/templates/CommonAdmin/DeleteAction/index.php.twig
@@ -13,7 +13,7 @@
             $this->postRemove(${{ builder.ModelClass }});
 
             $this->get('session')->setFlash('success', $this->get('translator')->trans("{{ messages.success is defined ? messages.success : "object.deleted.success" }}", array(), 'Admingenerator') );
-        } catch (\InvalidArgumentException $e) {
+        } catch (\Exception $e) {
             $this->get('session')->setFlash('error', $this->get('translator')->trans("{{ messages.error is defined ? messages.error : "object.deleted.error" }}", array(), 'Admingenerator') );
             $this->onException($e, ${{ builder.ModelClass }});
         }


### PR DESCRIPTION
Catching all exceptions to display nice flash message "can't delete this object".

Catching only InvalidArgumentException caused symfony2 stack trace (in dev mode)/500 error page (in prod mode) when any other exception was throwed.

In my case I tried to delete some objects with foreign key contrains which caused SQL error.
