### PR TITLE
Update Routing/RoutingLoader.php to avoid conflict with composer intallation tree

### DIFF
--- a/Routing/RoutingLoader.php
+++ b/Routing/RoutingLoader.php
@@ -124,6 +124,6 @@ class RoutingLoader extends FileLoader
     {
         preg_match('#.+/(.+)/(.+Bundle)/Controller?/(.*?)/?$#', $resource, $matches);
 
-        return str_replace('/', '\\', $matches[2]);
+        return str_replace('/', '\\', $matches[1]);
     }
 }


### PR DESCRIPTION
I've updated this bundle to newest version and I have the error :

```
Cannot import resource "[..]/OAuthServerBundle/Controller/Client/" from "[..]/config/routing.yml". 
```

Of course, my resource is 

```
/var/local/webroot/project/vendor/author-name/oauth-server-bundle/VendorName/OAuthServerBundle/Controller/Client/
```

and the RoutingLoader::getNamespaceFromResource preg_match expression is

```
'#.+/(src|bundles)/(.+)/(.+Bundle)/Controller?/(.*?)/?$#'
```

(related to #79)

and I have no src or bundles repository, but a vendor one ...
