### PR TITLE
Stabilizing feat-twitter-theme and last features for RC1

### DIFF
--- a/Form/Extension/AutocompleteTypeExtension.php
+++ b/Form/Extension/AutocompleteTypeExtension.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Admingenerator\GeneratorBundle\Form\Extension;
+
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+/**
+ * @author havvg <tuebernickel@gmail.com>
+ */
+class AutocompleteTypeExtension extends AbstractTypeExtension
+{
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        if (false === $options['autocomplete']) {
+            $options['autocomplete'] = 'off';
+        }
+
+        // It doesn't hurt even if it will be left empty.
+        if (empty($view->vars['attr'])) {
+            $view->vars['attr'] = array();
+        }
+
+        if (null !== $options['autocomplete']) {
+            $view->vars['attr'] = array_merge(array(
+                'autocomplete' => $options['autocomplete'],
+                'x-autocompletetype' => $options['autocomplete'],
+            ), $view->vars['attr']);
+        }
+    }
+
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $resolver->setDefaults(array(
+            'autocomplete' => null,
+        ));
+    }
+
+    public function getExtendedType()
+    {
+        return 'form';
+    }
+}
+?>

--- a/Form/Extension/HelpMessageTypeExtension.php
+++ b/Form/Extension/HelpMessageTypeExtension.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Admingenerator\GeneratorBundle\Form\Extension;
+
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+/**
+ * @author havvg <tuebernickel@gmail.com>
+ */
+class HelpMessageTypeExtension extends AbstractTypeExtension
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->setAttribute('help', $options['help']);
+    }
+
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        $view->vars['help'] = $form->getConfig()->getAttribute('help');
+    }
+
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $resolver->setDefaults(array(
+            'help' => null,
+        ));
+    }
+
+    public function getExtendedType()
+    {
+        return 'form';
+    }
+}
+?>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -71,9 +71,17 @@
             <argument type="service" id="service_container" />
         </service>
         
-        <!-- Form type extensions -->
+        <!-- Form type extensions -->        
+        <service id="form.type_extension.autocomplete" class="Admingenerator\GeneratorBundle\Form\Extension\AutocompleteTypeExtension">
+            <tag name="form.type_extension" alias="form" />
+        </service>
+        
         <service id="form.type_extension.collection" class="Admingenerator\GeneratorBundle\Form\Extension\BootstrapCollectionTypeExtension">
             <tag name="form.type_extension" alias="collection" />
+        </service>
+        
+        <service id="form.type_extension.help_message" class="Admingenerator\GeneratorBundle\Form\Extension\HelpMessageTypeExtension">
+            <tag name="form.type_extension" alias="form" />
         </service>
 
         <!-- Warmup -->

--- a/Resources/public/css/bootstrap-extended.css
+++ b/Resources/public/css/bootstrap-extended.css
@@ -149,6 +149,14 @@ fieldset.collection-item {
   vertical-align: top
 }
 
+fieldset.collection-item > legend > label {
+  display: inline;
+  margin: 0;
+  font-size: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+}
+
 fieldset.collection-item > .delete {
   position: absolute;
   top: 5px;
@@ -171,6 +179,11 @@ fieldset.collection-item > .btn-toggle {
 
 fieldset.collection-item > .btn-toggle > input[type="checkbox"] {
   opacity: 0.65;
+}
+
+/* Form error styles */
+ul.form-errors {
+  margin-left: 15px;
 }
 
 /* Remove firefox grey dotted focus outline */

--- a/Resources/templates/CommonAdmin/EditTemplate/fieldset.php.twig
+++ b/Resources/templates/CommonAdmin/EditTemplate/fieldset.php.twig
@@ -11,21 +11,9 @@
                           {{ echo_if_granted(builder.Columns[field].credentials, builder.ModelClass) }}
                     {% endif %}
                     <div class="control-group form_field field_{{ builder.Columns[field].formType }} field_{{ field }}">
-                    {{ echo_block("form_" ~ field) }}
-                        <div class="error">
-                            {{ echo_twig("form_errors(form['" ~ field ~ "'])") }}
-                        </div>
-                        {{ echo_twig("form_label(form['" ~ field ~ "'], '" ~ builder.Columns[field].label|addslashes ~ "'|trans({}, '" ~ (i18n_catalog is defined ? i18n_catalog : "Admin") ~ "'))") }}
-                        <div class="controls">
-                            {{- echo_twig("form_widget(form['" ~ field ~ "'])") -}}
-
-                            {%- if builder.columns[field].help %}
-                            <span class="help-inline">
-                                {{ echo_twig("'" ~ builder.columns[field].help|addslashes ~ "'|trans({}, '" ~ (i18n_catalog is defined ? i18n_catalog : "Admin") ~ "')") }}
-                            </span>
-                            {% endif -%}
-                        </div>
-                    {{ echo_endblock() }}
+                        {{ echo_block("form_" ~ field) }}
+                            {{ echo_twig("form_row(form['" ~ field ~ "'])") }}
+                        {{ echo_endblock() }}
                     </div>
                     {% if builder.Columns[field].credentials %}
                         {{ echo_endif () }}

--- a/Resources/templates/CommonAdmin/EditType/type.php.twig
+++ b/Resources/templates/CommonAdmin/EditType/type.php.twig
@@ -21,7 +21,9 @@ class {{ builder.YamlKey|ucfirst }}Type extends AbstractType
           {% set columnType = column.formType|as_php|convert_as_form('form_widget') %}
           {% set columnOptions = column.formOptions %}
               {% if column.label is defined %}{% set columnOptions = columnOptions|merge({'label': column.label}) %}{% endif %}
-          {% set columnOptions = columnOptions|i18n(i18n_catalog|default('Admin'))|as_php|convert_as_form(column.formType) %}
+              {% if column.help is defined %}{% set columnOptions = columnOptions|merge({'help': column.help}) %}{% endif %}
+              {% set columnOptions = columnOptions|merge({'translation_domain': i18n_catalog|default('Admin')}) %}
+          {% set columnOptions = columnOptions|as_php|convert_as_form(column.formType) %}
 
            $builder->add('{{ column.name }}', {{ columnType }}, {{ columnOptions }});
            

--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -136,6 +136,7 @@
     <fieldset class="collection-item {{ id ~ '_actions' }}">
         <legend>{{ form_label(item) }}</legend>
         {{ form_widget(item) }}
+        {{ form_errors(item) }}
         {% include "AdmingeneratorGeneratorBundle:Form/Collection:collection_delete.html.twig" %}
     </fieldset>
 {% endspaceless %}
@@ -156,7 +157,7 @@
         {% endif %}
         <thead>
           <tr>
-            <td id="{{ id ~ '_toolbar' }}" class="btn-toolbar form-actions form-actions-condensed" colspan="3">
+            <td id="{{ id ~ '_toolbar' }}" class="btn-toolbar form-actions form-actions-condensed" colspan="4">
                 {% include "AdmingeneratorGeneratorBundle:Form/Collection:collection_add.html.twig" %}
                 {% include "AdmingeneratorGeneratorBundle:Form/Collection:collection_batch_delete.html.twig" %}
             </td>
@@ -177,6 +178,7 @@
     <tr class="collection-item">
         <th class="new-label">{{ form_label(item) }}</th>
         <td>{{ form_widget(item) }}</td>
+        <td>{{ form_errors(item) }}</td>
         <td class="{{ id ~ '_actions' }}">{% include "AdmingeneratorGeneratorBundle:Form/Collection:collection_delete.html.twig" %}</td>
     </tr>
 {% endspaceless %}
@@ -184,7 +186,7 @@
     
 {% block form_widget_compound %}
 {% spaceless %}
-    <div class="control-group" {{ block('widget_container_attributes') }}>
+    <div {{ block('widget_container_attributes') }}>
         {% if form.parent is empty %}
             {{ form_errors(form) }}
         {% endif %}
@@ -210,10 +212,15 @@
     
 {% block form_row %}
 {% spaceless %}
-    <div class="control">
+    <div class="control-group {% if errors|length > 0 %} error{% endif %}">
         {{ form_label(form) }}
-        {{ form_errors(form) }}
+        <div class="controls">
         {{ form_widget(form) }}
+        {% if not compound %}
+            {{ form_errors(form) }}
+        {% endif %}
+        {{ block('form_help') }}
+        </div>
     </div>
 {% endspaceless %}
 {% endblock form_row %}
@@ -233,3 +240,30 @@
     <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>{{ label|trans({}, translation_domain) }}</label>
 {% endspaceless %}
 {% endblock form_label %}
+    
+{% block form_errors %}
+{% spaceless %}
+    {% if errors|length > 0 %}
+    <span class="help-block">
+        <ul class="form-errors">
+        {% for error in errors %}
+            <li>{{ error.messagePluralization is null
+                ? error.messageTemplate|trans(error.messageParameters, 'validators')
+                : error.messageTemplate|transchoice(error.messagePluralization, error.messageParameters, 'validators')
+            }}</li>
+        {% endfor %}
+        </ul>
+    </span>
+    {% endif %}
+{% endspaceless %}
+{% endblock form_errors %}
+    
+{% block form_help %}
+{% spaceless %}
+    {% if help %}
+        <span class="help-block">
+            <p class="muted">{{ help|trans({}, translation_domain) }}</p>
+        </span>
+    {% endif %}
+{% endspaceless %}
+{% endblock form_help %}

--- a/Tests/Twig/Extension/EchoExtensionTest.php
+++ b/Tests/Twig/Extension/EchoExtensionTest.php
@@ -41,21 +41,6 @@ class EchoExtensionTest extends TestCase
         );
     }
 
-    public function testI18n()
-    {
-        $tpls = array(
-            'string' => '{{ "cedric"|i18n("foo") }}',
-            'array' => '{{ arr|i18n("foo")|as_php }}',
-        );
-
-        $returns = array(
-            'string' => array("cedric", 'i18n does not modify the string'),
-            'array' => array("array(  'obj' => 'val',  'translation_domain' => 'foo',)", 'i18n succesfully adds translation_domain to the array'),
-        );
-
-       $this->runTwigTests($tpls, $returns);
-    }
-
     public function testConvertAsForm()
     {
 

--- a/Twig/Extension/EchoExtension.php
+++ b/Twig/Extension/EchoExtension.php
@@ -46,25 +46,7 @@ class EchoExtension extends \Twig_Extension
         return array(
             'as_php'          => new \Twig_Filter_Method($this, 'asPhp'),
             'convert_as_form' => new \Twig_Filter_Method($this, 'convertAsForm'),
-            'i18n'            => new \Twig_Filter_Method($this, 'i18n'),
         );
-    }
-    
-    /**
-     * Pass i18n_catalog to form options as translation_domain
-     * 
-     * @param array $variable
-     * @param type $i18n_catalog translation domain
-     * @return array
-     */
-    public function i18n($variable, $i18n_catalog)
-    { 
-       if (!is_array($variable)) {
-           return $variable;
-       }
-       
-       $variable['translation_domain'] = $i18n_catalog;
-       return $variable;
     }
 
     /**


### PR DESCRIPTION
- added HelpMessageTypeExtension
- added AutocompleteTypeExtension
- updated services.xml to add HelpMessageTypeExtension and AutocompleteTypeExtension
- updated bootstrap-extended.css to add ul.form-errors style and fix fieldset collection legend label styles
- updated fields.html to add form_errors, form_help blocks and update form_row, form_widget_compound
- updated type.php.twig (removed i18n twig extension call, instead adding label, help and translation_domain directly in type.php.twig)
- updated EchoExtension (removing unnecessary i18n twig extension)
- updated EchoExtensionTest (removeing unnecessary i18n test)
- updated fieldset.php.twig (useing form_row instead of form_label/form_widget/form_errors combination)
- added error display for collection fieldset and table widgets
