### PR TITLE
List - Use Entity's Repository to create QueryBuilder

### DIFF
--- a/Resources/templates/Doctrine/ListBuilderAction.php.twig
+++ b/Resources/templates/Doctrine/ListBuilderAction.php.twig
@@ -65,9 +65,8 @@
     {
         return $this->getDoctrine()
                     ->getEntityManager()
-                    ->createQueryBuilder()
-                    ->select('q')
-                    ->from('{{ model }}', 'q');
+                    ->getRepository('{{ model }}')
+                    ->createQueryBuilder('q');
     }
 {% endblock %}
 


### PR DESCRIPTION
Instead of having the EntityManager create the QueryBuilder, use the Entity's Repository to create the QueryBuilder.  

This would help users that extend the default EntityRepository.  

Thoughts?
