### PR TITLE
Fix NotFoundException when using auto increment id strategy

### DIFF
--- a/Resources/templates/DoctrineODM/EditBuilderAction.php.twig
+++ b/Resources/templates/DoctrineODM/EditBuilderAction.php.twig
@@ -2,6 +2,8 @@
 {% block getObject -%}
     protected function getObject($pk)
     {
+        $pk = is_numeric($pk) ? intval($pk) : $pk;
+
         return $this->getDocumentManager()
                     ->getRepository('{{ model }}')
                     ->find($pk);


### PR DESCRIPTION
The generated Doctrine ODM EditController can not handling numeric key.
If the document id assumes numeric. Convert it to integer.
