### PR TITLE
Changed call of isGranted

### DIFF
--- a/Resources/templates/CommonAdmin/security_action.php.twig
+++ b/Resources/templates/CommonAdmin/security_action.php.twig
@@ -17,7 +17,7 @@ use JMS\SecurityExtraBundle\Security\Authorization\Expression\Expression;
     {
         $securityContext = $this->get('security.context');
 
-        if (false === $securityContext->isGranted(array(new Expression('{{ credentials }}', ${{ builder.ModelClass }})))) {
+        if (false === $securityContext->isGranted(array(new Expression('{{ credentials }}')), ${{ builder.ModelClass }})) {
             throw new AccessDeniedException();
         }
     }


### PR DESCRIPTION
This didn't work for me as it was.
The function header for isGranted is as follows:

```
final public function isGranted($attributes, $object = null)
```

It was called with $attributes = array(Expression, ModelClass) and $object was always = null

This didn't work, as the object was always null and always returned true.
