### PR TITLE
Changed isGranted in EditType

### DIFF
--- a/Resources/templates/CommonAdmin/EditType/type.php.twig
+++ b/Resources/templates/CommonAdmin/EditType/type.php.twig
@@ -15,7 +15,7 @@ class {{ builder.YamlKey|ucfirst }}Type extends AbstractType
     {
         {% for column in builder.columns %}
         {%- if column.credentials -%}
-        if (false !== $this->securityContext->isGranted(array(new Expression('{{ column.credentials }}')))) {
+        if (false !== $this->securityContext->isGranted(array(new Expression('{{ column.credentials }}')), $builder->getData())) {
         {%- endif %}
         
           {% set columnType = column.formType|as_php|convert_as_form('form_widget') %}


### PR DESCRIPTION
Get the object from the form, so the expression can also check for permissions through ACL.
The view CommonAdmin/EditTemplate/fieldset.php.twig already does the same thing as the updated code (line {{ echo_if_granted(builder.Columns[field].credentials, builder.ModelClass) }}).
