### PR TITLE
Change dependency on KnpMenuBundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "symfony/symfony": "2.1.*",
         "cedriclombardot/twig-generator": "dev-master",
-        "knplabs/knp-menu-bundle": "dev-master",
+        "knplabs/knp-menu-bundle": ">1.0,<2.1",
         "white-october/pagerfanta-bundle": "dev-master",
         "twig/twig": ">= 1.9.0",
         "twig/extensions": "dev-master"


### PR DESCRIPTION
The bundle seems to be working with KnpMenu 1.x, there is no need to force master. It's better to use version tags as dev-master limits greatly the compatibility with other bundles and is a maintenance nightmare.

On related subject - are you planning on introducing some tags to the bundle? Even if it was 0.x, it's still better than no tags at all.
