### PR TITLE
Support to call php code on any form option

### DIFF
--- a/Twig/Extension/EchoExtension.php
+++ b/Twig/Extension/EchoExtension.php
@@ -61,7 +61,7 @@ class EchoExtension extends \Twig_Extension
      */
     public function convertAsForm($options, $formType)
     {
-        $options = preg_replace("/'__php\((.+)\)'/i", '$1', $options, -1, $count);
+        $options = preg_replace("/'__php\((.+?)\)'/i", '$1', $options, -1, $count);
         
         if ('collection' == $formType || 'upload' == $formType) {
             preg_match("/'type' => '(.+?)'/i", $options, $matches);


### PR DESCRIPTION
Adds support to call custom php code on any form option.
The code which should be executed has to be wrapped with __php(<<php code>>).

Example usage:

``` yaml
addFormOptions:
    languages: __php($this->getLanguages())
    type: __php(new \Foo\Bar\BazType)
```
