### PR TITLE
Added nested_move to RoutingLoader actions

### DIFF
--- a/Routing/RoutingLoader.php
+++ b/Routing/RoutingLoader.php
@@ -69,6 +69,12 @@ class RoutingLoader extends FileLoader
                     'requirements' => array(),
                     'controller'   => 'list',
                 ),
+        'nested_move' => array(
+                    'pattern' => '/nested_move/{dragged}/{action}/{dropped}',
+                    'defaults' => array(),
+                    'requirements' => array(),
+                    'controller' => 'list'
+                ),
     );
 
     public function load($resource, $type = null)


### PR DESCRIPTION
I got it working this way. I'm not sure if its the right place though, because a `nested_move` route will be generated for every `generator.yml` even if it does not has a `nested_list` item in `builders'.
