### PR TITLE
Prebind request was missing from new action template

### DIFF
--- a/Resources/templates/CommonAdmin/NewAction/create.php.twig
+++ b/Resources/templates/CommonAdmin/NewAction/create.php.twig
@@ -9,6 +9,7 @@
 
         ${{ builder.ModelClass }} = $this->getNewObject();
 
+        $this->preBindRequest(${{ builder.ModelClass }});
         $form = $this->createForm($this->getNewType(), ${{ builder.ModelClass }});
         $form->bindRequest($this->get('request'));
 
@@ -53,6 +54,15 @@
         if ($this->container->getParameter('kernel.debug')) {
             throw $exception;
         }
+    }
+
+    /**
+     * This method is here to make your life better, so overwrite  it
+     *
+     * @param \{{ model }} ${{ builder.ModelClass }} your \{{ model }} object
+     */
+    public function preBindRequest(\{{ model }} ${{ builder.ModelClass }})
+    {
     }
 
     /**


### PR DESCRIPTION
I couldn't find any references to this issue so I don't know if it was made on purpose but [new action create template](https://github.com/symfony2admingenerator/AdmingeneratorGeneratorBundle/blob/master/Resources/templates/CommonAdmin/NewAction/create.php.twig#L11) was missing [preBindRequest()](https://github.com/symfony2admingenerator/AdmingeneratorGeneratorBundle/blob/master/Resources/templates/CommonAdmin/EditAction/update.php.twig#L16) method.
