### PR TITLE
[FIX] ODM double list type renamed

### DIFF
--- a/Guesser/DoctrineODMFieldGuesser.php
+++ b/Guesser/DoctrineODMFieldGuesser.php
@@ -110,7 +110,7 @@ class DoctrineODMFieldGuesser
                 return 'document';
                 break;
              case 'collection':
-                return 'doctrine_odm_double_list';
+                return 'double_list';
                 break;
             case 'hash':
                 return 'collection';


### PR DESCRIPTION
@loostro: Your last commit to [config/doctrine_odm.xml](https://github.com/symfony2admingenerator/AdmingeneratorGeneratorBundle/blob/master/Resources/config/doctrine_odm.xml) broke double list for mongodb. [DoctrineODMFieldGuesser](https://github.com/symfony2admingenerator/AdmingeneratorGeneratorBundle/blob/master/Guesser/DoctrineODMFieldGuesser.php) was still looking for 'doctrine_odm_double_list' although it was renamed to 'double_list' on your commit 909ea171d1a0fc208a8f3210cbe8b0c52b080f3c 5 days ago.

Also: There seems to be a problem with composer requirements. You can see the Travis log here: https://api.travis-ci.org/jobs/5001386/log.txt?deansi=true
