### PR TITLE
Target document is not always available.

### DIFF
--- a/Guesser/DoctrineODMFieldGuesser.php
+++ b/Guesser/DoctrineODMFieldGuesser.php
@@ -163,7 +163,7 @@ class DoctrineODMFieldGuesser
         if ('collection' == $dbType) {
             $mapping = $this->getMetadatas()->getFieldMapping($columnName);
 
-            return array('class' => $mapping['targetDocument']);
+            return array('class' => isset($mapping['targetDocument']) ? $mapping['targetDocument'] : null);
         }
 
         if ('collection' == $formType) {


### PR DESCRIPTION
The mongodb odm documentation indicates that `targetDocument` is
optional. This was causing an undefined index notice when it was not
specified.
