### PR TITLE
Allow using propel camelcased column names in generator.yml

### DIFF
--- a/Guesser/PropelORMFieldGuesser.php
+++ b/Guesser/PropelORMFieldGuesser.php
@@ -267,7 +267,7 @@ class PropelORMFieldGuesser
             return $this->cache[$class.'::'.$property] = $table->getColumn($property);
         } else {
             foreach ($table->getColumns() as $column) {
-                if (Inflector::tableize($column->getPhpName()) === $property) {
+                if (Inflector::tableize($column->getPhpName()) === $property || $column->getPhpName() === ucfirst($property)) {
                     return $this->cache[$class.'::'.$property] = $column;
                 }
             }


### PR DESCRIPTION
I have "publicationDate" getter in my validation.yml, so when form is created with publication_date field from generator.yml the error is not mapped correctly (it is made global since there is no publicationDate form field)
