### PR TITLE
make blur event customizable on typeahead

### DIFF
--- a/Resources/public/js/bootstrap/bootstrap-typeahead-extended.js
+++ b/Resources/public/js/bootstrap/bootstrap-typeahead-extended.js
@@ -37,6 +37,7 @@
     this.updater = this.options.updater || this.updater
     this.getter = this.options.getter || this.getter
     this.setter = this.options.setter || this.setter
+    this.blur = this.options.blur || this.blur
     this.$menu = $(this.options.menu).appendTo('body')
     this.source = this.options.source
     this.shown = false


### PR DESCRIPTION
It would be pretty cool when extending EntityPickerType. On blur event we could check if value is a selected value or a value to create by a DataTransformer...
