### PR TITLE
Fix: Date and DateTime column showing null values as current time.

### DIFF
--- a/Resources/templates/CommonAdmin/ListTemplate/Column/date.php.twig
+++ b/Resources/templates/CommonAdmin/ListTemplate/Column/date.php.twig
@@ -1,7 +1,11 @@
 {% block column_date %}
     {%- if builder.generator.TwigParams.use_localized_date == true -%}
-        {{- echo_twig(builder.ModelClass ~ '.' ~ column.getter ~ '|localizeddate("' ~ builder.generator.TwigParams.localized_date_format ~ '", "none")') -}}
+        {{ echo_if (builder.ModelClass ~ '.' ~ column.getter) }}
+            {{- echo_twig(builder.ModelClass ~ '.' ~ column.getter ~ '|localizeddate("' ~ builder.generator.TwigParams.localized_date_format ~ '", "none")') -}}
+        {{ echo_endif() }}
     {%- else -%}
-        {{- echo_twig(builder.ModelClass ~ '.' ~ column.getter ~ '|date("' ~ builder.generator.TwigParams.date_format ~ '")') -}}
+        {{ echo_if (builder.ModelClass ~ '.' ~ column.getter) }}
+            {{- echo_twig(builder.ModelClass ~ '.' ~ column.getter ~ '|date("' ~ builder.generator.TwigParams.date_format ~ '")') -}}
+        {{ echo_endif() }}
     {%- endif -%}
 {% endblock %}

--- a/Resources/templates/CommonAdmin/ListTemplate/Column/datetime.php.twig
+++ b/Resources/templates/CommonAdmin/ListTemplate/Column/datetime.php.twig
@@ -1,7 +1,11 @@
 {% block column_datetime %}
     {%- if builder.generator.TwigParams.use_localized_date == true -%}
-        {{- echo_twig(builder.ModelClass ~ '.' ~ column.getter ~ '|localizeddate("' ~ builder.generator.TwigParams.localized_date_format ~ '", "' ~ builder.generator.TwigParams.localized_datetime_format ~ '")') -}}
+        {{ echo_if (builder.ModelClass ~ '.' ~ column.getter) }}
+            {{- echo_twig(builder.ModelClass ~ '.' ~ column.getter ~ '|localizeddate("' ~ builder.generator.TwigParams.localized_date_format ~ '", "' ~ builder.generator.TwigParams.localized_datetime_format ~ '")') -}}
+        {{ echo_endif() }}
     {%- else -%}
-        {{- echo_twig(builder.ModelClass ~ '.' ~ column.getter ~ '|date("' ~ builder.generator.TwigParams.datetime_format ~ '")') -}}
+        {{ echo_if (builder.ModelClass ~ '.' ~ column.getter) }}
+            {{- echo_twig(builder.ModelClass ~ '.' ~ column.getter ~ '|date("' ~ builder.generator.TwigParams.datetime_format ~ '")') -}}
+        {{ echo_endif() }}
     {%- endif -%}
 {% endblock %}


### PR DESCRIPTION
Currently null values display as today's date and time in the twigbuilder templates.

Added IF to check these fields are set before passing to the date filter.
