### PR TITLE
Allow multiple "NONE" group for fieldset

### DIFF
--- a/Resources/templates/CommonAdmin/EditTemplate/fieldset.php.twig
+++ b/Resources/templates/CommonAdmin/EditTemplate/fieldset.php.twig
@@ -1,7 +1,7 @@
 {% block form_fieldset %}
 {{ echo_block("form_fieldset_" ~ fieldset|classify|replace({'.': '_'})) }}
     <fieldset class="form_block form_fieldset_{{ fieldset|classify|replace({'.': '_'}) }} fieldset_tabbable">
-        {% if "NONE" != fieldset %}
+        {% if "NONE" != fieldset[:4] %}
         <legend><span>{{ echo_trans(fieldset,{}, i18n_catalog is defined ? i18n_catalog : "Admin" ) }}</span></legend>
         {% endif %}
         {% for rows in builder.fieldsets[fieldset] %}


### PR DESCRIPTION
Before this PR if you want to use fieldsets but not define legends, you cannot (usefull in tab context for example).
With this PR, if your fieldset starts with special word "NONE", legend will not be added.
