### PR TITLE
[FIX] Remove deprecated call for symfony23

### DIFF
--- a/CacheWarmer/GeneratorCacheWarmer.php
+++ b/CacheWarmer/GeneratorCacheWarmer.php
@@ -91,7 +91,6 @@ class GeneratorCacheWarmer implements CacheWarmerInterface
 
     protected function parseYaml($file)
     {
-        Yaml::enablePhpParsing(true);
         $this->yaml_datas = Yaml::parse($file);
     }
 


### PR DESCRIPTION
Referring issue #452, PHP parsing is effectively not allowed anymore in Yaml file since Symfony2.3.

But, AFAIK, Admingenerator doesn't use PHP in generator.yml files.
Builder doesn't use PHP parsing as you can see in `Admingenerator\GeneratorBundle\Builder\Generator` on line 42. So here, in `CacheWarmer/GeneratorCacheWarmer.php` line 94, PHP parsing doesn't seems to be legal.

This PR simply removes this line in `CacheWarmer/GeneratorCacheWarmer.php`.
