### PR TITLE
[FIX] Issue 452: removing deprecated call (Yaml::enablePhpParsing)

### DIFF
--- a/EventListener/ControllerListener.php
+++ b/EventListener/ControllerListener.php
@@ -57,7 +57,6 @@ class ControllerListener
 
     protected function getGenerator($generatorYaml)
     {
-        Yaml::enablePhpParsing(true);
         $yaml = Yaml::parse($generatorYaml);
 
         return $this->container->get($yaml['generator']);


### PR DESCRIPTION
See issue #452
