### PR TITLE
Doctrine MongoDB wrong registry

### DIFF
--- a/Controller/DoctrineODM/BaseController.php
+++ b/Controller/DoctrineODM/BaseController.php
@@ -15,7 +15,7 @@ abstract class BaseController extends Controller
     /**
      * @return \Doctrine\Bundle\MongoDBBundle\ManagerRegistry
      */
-    public function getDoctrine()
+    public function getDoctrineMongoDB()
     {
         if (!$this->container->has('doctrine_mongodb')) {
             throw new \LogicException('The DoctrineMongoDBBundle is not registered in your application.');

--- a/Resources/templates/DoctrineODM/ListBuilderAction.php.twig
+++ b/Resources/templates/DoctrineODM/ListBuilderAction.php.twig
@@ -41,7 +41,7 @@ use Pagerfanta\Adapter\DoctrineODMMongoDBAdapter as PagerAdapter;
             {%- if 'document' == builder.getFieldGuesser().getDbType(model, filter) or 'collection' == builder.getFieldGuesser().getDbType(model, filter) -%}
 
         if (isset($filters['{{ filter }}'])) {
-                $filters['{{ filter }}'] = $this->getDoctrine()->getRepository($filters['{{ filter }}']['documentName'])->find($filters['{{ filter }}']['id']);
+                $filters['{{ filter }}'] = $this->getDoctrineMongoDB()->getRepository($filters['{{ filter }}']['documentName'])->find($filters['{{ filter }}']['id']);
         }
 
             {%- endif %}
@@ -189,7 +189,7 @@ use Pagerfanta\Adapter\DoctrineODMMongoDBAdapter as PagerAdapter;
 {% block doBatchDelete -%}
     protected function doBatchDelete(array $ids)
     {
-        if ($this->getDoctrine()
+        if ($this->getDoctrineMongoDB()
             ->getDocumentManager()
             ->createQuery(sprintf('delete from {{ model }} q where q.{{ builder.getFieldGuesser().getModelPrimaryKeyName(model) }} IN (%s)', implode(',', $ids)))
             ->execute()) {


### PR DESCRIPTION
Currently mongodb filters and batch delete actions rely on `getDoctrine()` method from the symfony base controller.

As that method returns the service `doctrine` instead of `doctrine_mongodb` Registry throws an invalid mapping exception error. 

I've added a new method to mongodb `BaseController` which returns `doctrine_mongodb`.

This should also fix #228
