### PR TITLE
Fix for deprecated call getParent() on FormBuilderInterface

### DIFF
--- a/Form/Type/DoctrineORM/SingleUploadType.php
+++ b/Form/Type/DoctrineORM/SingleUploadType.php
@@ -33,7 +33,7 @@ class SingleUploadType extends FileType
             $options['nameable'],
             $options['deleteable']
         );
-        $builder->getParent()->addEventSubscriber($singleUploadNamerListener);
+        $builder->addEventSubscriber($singleUploadNamerListener);
 
         $builder->setAttribute('thumbnail_generator', $this->container->getParameter('admingenerator.thumbnail_generator'));
     }

--- a/Form/Type/DoctrineORM/UploadType.php
+++ b/Form/Type/DoctrineORM/UploadType.php
@@ -39,7 +39,7 @@ class UploadType extends CollectionType
             $options['options']['data_class'],
             $options['nameable']
         );
-        $builder->getParent()->addEventSubscriber($captureListener);
+        $builder->addEventSubscriber($captureListener);
 
         $resizeListener = new ResizeFormListener(
             $options['type'],


### PR DESCRIPTION
Seems to work without the getParent() call. 
