### PR TITLE
getClientData does not work in 2.3

### DIFF
--- a/Resources/templates/CommonAdmin/ListAction/filters.php.twig
+++ b/Resources/templates/CommonAdmin/ListAction/filters.php.twig
@@ -12,7 +12,7 @@
             $form->bind($this->get('request'));
 
             if ($form->isValid()) {
-                $filters = $form->getClientData();
+                $filters = $form->getViewData();
             }
         }
 


### PR DESCRIPTION
The method `getClientData` has a new equivalent that is named `getViewData`
