### PR TITLE
Change humanize column name

### DIFF
--- a/Generator/Column.php
+++ b/Generator/Column.php
@@ -124,7 +124,7 @@ class Column
 
     private function humanize($text)
     {
-        return ucfirst(strtolower(str_replace('_', ' ', $text)));
+        return ucfirst(str_replace('_', ' ', $text));
     }
 
     public function setDbType($dbType)


### PR DESCRIPTION
Before this PR column `$productsRelatedToMe` would be humanized to "Productsrelatedtome" which is not actually readable!
After this PR the same column will be humanized to "ProductsRelatedToMe".
