### PR TITLE
Fix classLoader and EmptyBuilder for classes with complex namespaces

### DIFF
--- a/ClassLoader/AdmingeneratedClassLoader.php
+++ b/ClassLoader/AdmingeneratedClassLoader.php
@@ -51,18 +51,23 @@ class AdmingeneratedClassLoader
     {
         $generator = new EmptyGenerator($this->base_path);
 
-        list($admingenerated, $bundle, $baseController, $controllerName) = explode('\\',$class);
+        $parts = explode('\\',$class);
+        $controllerName = $parts[count($parts) - 1];
+        unset($parts[count($parts) - 1]);
+
+        $namespace = implode('\\', $parts);
+        $fileName = str_replace('\\', DIRECTORY_SEPARATOR, $class);
 
         $builder = new EmptyBuilderAction();
         $generator->addBuilder($builder);
-        $builder->setOutputName($baseController.'/'.$controllerName.'.php');
+        $builder->setOutputName($fileName.'.php');
+
         $builder->setVariables(array(
             'controllerName' => $controllerName,
-            'bundle'         => $bundle,
-            'base_controller' => $baseController,
+            'namespace'      => $namespace,
         ));
 
-        $generator->writeOnDisk($this->base_path."/$admingenerated/$bundle");
+        $generator->writeOnDisk($this->base_path);
     }
 
 }

--- a/Resources/templates/EmptyBuilderAction.php.twig
+++ b/Resources/templates/EmptyBuilderAction.php.twig
@@ -1,6 +1,6 @@
 <?php
 
-namespace Admingenerated\{{ bundle }}\{{ base_controller }};
+namespace {{ namespace }};
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Admingenerator\GeneratorBundle\Exception\CantGenerateException;


### PR DESCRIPTION
When the namespace contains subfolder the warmup fail
With this new method, we split the required class and generate the exact namespace asked in the good file
