### PR TITLE
[FIX] Show template generation if sidebar is not defined

### DIFF
--- a/Resources/templates/CommonAdmin/ShowTemplate/ShowBuilderTemplate.php.twig
+++ b/Resources/templates/CommonAdmin/ShowTemplate/ShowBuilderTemplate.php.twig
@@ -26,12 +26,12 @@
     {{- block('title') -}}
 
     <div class="row-fluid">
-        {% if sidebar  %}
+        {% if sidebar is defined and sidebar|length > 0 %}
             <div class="span8">
         {% endif %}
                 {{- block('show_tabs') }}
                 {{- block('show') -}}
-        {% if sidebar %}
+        {% if sidebar is defined and sidebar|length > 0 %}
             </div>
             <div class="span4">
                 {{- block('show_sidebar') -}}


### PR DESCRIPTION
If sidebar param doesn't exists in show builder, show template couldn't be rendered.

``` shell
[Twig_Error_Runtime]                                                                                        
  Variable "sidebar" does not exist in "../CommonAdmin/ShowTemplate/ShowBuilderTemplate.php.twig" at line 29  
```

This PR fix, that issue.
