### PR TITLE
Fix invalid option "help"

### DIFF
--- a/Resources/templates/CommonAdmin/EditType/type.php.twig
+++ b/Resources/templates/CommonAdmin/EditType/type.php.twig
@@ -20,7 +20,6 @@ class {{ builder.YamlKey|ucfirst }}Type extends AbstractType
 
         $formOptions = $this->getFormOption('{{ column.name }}', {{ column.formOptions|merge({
             'label': column.label,
-            'help': column.help|default(''),
             'translation_domain': i18n_catalog|default('Admin')
         })|as_php }});
         $builder->add('{{ column.name }}', {{ column.formType|as_php }}, $formOptions);


### PR DESCRIPTION
If we don't use any specific form bundle, option "help" doesn't exists.

So option "help" should not be added to generated types.
