### PR TITLE
Sensio generator bundle 2.3 requirement added

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     ],
     "require": {
         "symfony/symfony": ">= 2.2.0",
+        "sensio/generator-bundle": ">= 2.3",
         "cedriclombardot/twig-generator": "1.0.*",
         "knplabs/knp-menu-bundle": ">1.0,<2.1",
         "white-october/pagerfanta-bundle": "1.0.*@dev",


### PR DESCRIPTION
`GenerateAdminAdminCommand:updateRouting` method requires at least sensio generator bundle 2.3 as previous versions don't work due to incompatible declaration.

You can see the overriden sensio method here: https://github.com/sensiolabs/SensioGeneratorBundle/compare/2.2...master#L0L299
