### PR TITLE
Fix localized date

### DIFF
--- a/Resources/doc/builders/common/localized-date.md
+++ b/Resources/doc/builders/common/localized-date.md
@@ -1,0 +1,126 @@
+# Localized date
+---------------------------------------
+
+[go back to Table of contents][back-to-index]
+
+[back-to-index]: https://github.com/symfony2admingenerator/AdmingeneratorGeneratorBundle/blob/master/Resources/doc/builders/list
+
+Admingenerator comes with a few configuration options allowing you to control 
+the outputted date format. 
+
+```yaml
+admingenerator_generator:
+    twig:
+        use_localized_date:           false
+    # by default the localized date is disabled thats why default settings 
+    # use PHP date()'s format if you enable localized date make sure to change 
+    # these to ISO 8601 compatible format!
+        date_format:                  "Y-m-d"         # for ISO 8601 "yyyy-MM-dd"
+        datetime_format:              "Y-m-d H:i:s"   # for ISO 8601 "yyyy-MM-dd HH:mm:ss"
+        localized_date_format:        "medium"
+        localized_datetime_format:    "medium"
+```
+
+> **Note:** these apply only to `list` and `show` builders. These settings have no effect on
+`edit` and `new` forms.
+
+> **WARNING!** Internally localized date is handled by [IntlDateFormatter class][intl-date-formatter], 
+which uses [ISO 8601][iso-8601] formats instead of PHP date()'s formats. Make sure to set the correct
+`date_format` and `datetime_format` if you enable localized date!
+
+[intl-date-formatter]: http://www.php.net/manual/en/intldateformatter.format.php
+[iso-8601]: http://framework.zend.com/manual/1.12/en/zend.date.constants.html#zend.date.constants.selfdefinedformats
+
+### Description
+
+##### date fields
+
+If `use_localized_date` is enabled, the date field will be rendered as:
+
+```html+django
+  {{ my_date|localizeddate(localized_date_format, "none", null, null, date_format) }}
+```
+
+Otherwise the date field will be rendered as:
+
+```html+django
+  {{ my_date|date(date_format) }}
+```
+
+Where `date_format` is equal to `format` option for that field (if defined) or will 
+fallback to `date_format` setting.
+
+##### datetime fields
+
+If `use_localized_date` is enabled, the datetime field will be rendered as:
+
+```html+django
+  {{ my_date|localizeddate(localized_datetime_format, localized_datetime_format, null, null, datetime_format) }}
+```
+
+Otherwise the date field will be rendered as:
+
+```html+django
+  {{ my_date|date(date_format) }}
+```
+
+Where `datetime_format` is equal to `format` option for that field (if defined) or will 
+fallback to `datetime_format` setting.
+
+### Options
+
+##### use_localized_date
+
+**type**: `bool`, **default**: `false`
+
+If true, enables transforming dates into their localized versions.
+
+##### date_format
+
+**type**: `string`, **default**: `Y-m-d`
+
+If `use_localized_date` is false, use formats for PHP's `date()` function, otherwise use 
+[ISO 8601][iso-8601] formats.
+
+##### datetime_format
+
+**type**: `string`, **default**: `Y-m-d H:i:s`
+
+If `use_localized_date` is false, use formats for PHP's `date()` function, otherwise use 
+[ISO 8601][iso-8601] formats.
+
+##### localized_date_format
+
+**type**: `string`, **default**: `medium`
+
+Internally, we're useing [Twig Intl Extension][twig-intl-ext]. Possible options are:
+
+```php
+<?php
+array(
+  'none'    => IntlDateFormatter::NONE,
+  'short'   => IntlDateFormatter::SHORT,
+  'medium'  => IntlDateFormatter::MEDIUM,
+  'long'    => IntlDateFormatter::LONG,
+  'full'    => IntlDateFormatter::FULL,
+)
+```
+
+[twig-intl-ext]: https://github.com/fabpot/Twig-extensions/blob/master/lib/Twig/Extensions/Extension/Intl.php
+
+##### localized_datetime_format
+
+**type**: `string`, **default**: `medium`
+
+Internally, we're useing [Twig Intl Extension][twig-intl-ext]. Possible options are:
+
+```php
+<?php
+array(
+  'none'    => IntlDateFormatter::NONE,
+  'short'   => IntlDateFormatter::SHORT,
+  'medium'  => IntlDateFormatter::MEDIUM,
+  'long'    => IntlDateFormatter::LONG,
+  'full'    => IntlDateFormatter::FULL,
+)
+```

--- a/Resources/doc/builders/common/title.md
+++ b/Resources/doc/builders/common/title.md
@@ -1,0 +1,1 @@
+Sorry, this has not yet been rewritten.

--- a/Resources/doc/builders/list-builder.md
+++ b/Resources/doc/builders/list-builder.md
@@ -5,4 +5,9 @@
 
 [back-to-index]: https://github.com/symfony2admingenerator/AdmingeneratorGeneratorBundle/blob/master/Resources/doc/documentation.md#4-generator
 
-Sorry, this has not yet been rewritten.
+Sorry, this has not yet been completely rewritten.
+
+List builder features:
+
+* [Title](common/title.md)
+* [Localized date](common/localized-date.md)

--- a/Resources/templates/CommonAdmin/ListTemplate/Column/date.php.twig
+++ b/Resources/templates/CommonAdmin/ListTemplate/Column/date.php.twig
@@ -2,23 +2,28 @@
 {% spaceless %}
 {%- if builder.generator.TwigParams.use_localized_date == true -%}
     {{ echo_if (builder.ModelClass ~ '.' ~ column.getter) }}
-        {% if column.localized_date_format is defined %}
+        {%- if column.localized_date_format is defined -%}
             {{ echo_set('localized_date_format', column.formOptions.localized_date_format) }}
-        {% else %}
+        {%- else -%}
             {{ echo_set('localized_date_format', builder.generator.TwigParams.localized_date_format) }}
-        {% endif %}
+        {%- endif -%}
+        {%- if column.formOptions.format is defined -%}
+            {{ echo_set('date_format', column.formOptions.format) }}
+        {%- else -%}
+            {{ echo_set('date_format', builder.generator.TwigParams.date_format) }}
+        {%- endif -%}
 
-        {{- echo_twig(builder.ModelClass ~ '.' ~ column.getter ~ '|localizeddate(localized_date_format, "none")') -}}
+        {{ echo_twig(builder.ModelClass ~ '.' ~ column.getter ~ '|localizeddate(localized_date_format, "none", null, null, date_format)') }}
     {{ echo_endif() }}
 {%- else -%}
     {{ echo_if (builder.ModelClass ~ '.' ~ column.getter) }}
-        {% if column.formOptions.datetime_format is defined %}
-            {{ echo_set('datetime_format', column.formOptions.datetime_format) }}
-        {% else %}
-            {{ echo_set('datetime_format', builder.generator.TwigParams.datetime_format) }}
-        {% endif %}
+        {%- if column.formOptions.format is defined -%}
+            {{ echo_set('date_format', column.formOptions.format) }}
+        {%- else -%}
+            {{ echo_set('date_format', builder.generator.TwigParams.date_format) }}
+        {%- endif -%}
 
-        {{- echo_twig(builder.ModelClass ~ '.' ~ column.getter ~ '|date(datetime_format)') -}}
+        {{ echo_twig(builder.ModelClass ~ '.' ~ column.getter ~ '|date(date_format)') }}
     {{ echo_endif() }}
 {%- endif -%}
 {% endspaceless %}

--- a/Resources/templates/CommonAdmin/ListTemplate/Column/datetime.php.twig
+++ b/Resources/templates/CommonAdmin/ListTemplate/Column/datetime.php.twig
@@ -2,29 +2,33 @@
 {% spaceless %}
 {% if builder.generator.TwigParams.use_localized_date == true -%}
     {{ echo_if (builder.ModelClass ~ '.' ~ column.getter) }}
-        {% if column.localized_date_format is defined %}
+        {%- if column.localized_date_format is defined -%}
             {{ echo_set('localized_date_format', column.formOptions.localized_date_format) }}
-        {% else %}
+        {%- else -%}
             {{ echo_set('localized_date_format', builder.generator.TwigParams.localized_date_format) }}
-        {% endif %}
-
-        {% if column.localized_time_format is defined %}
+        {%- endif -%}
+        {%- if column.localized_time_format is defined -%}
             {{ echo_set('localized_time_format', column.formOptions.localized_datetime_format) }}
-        {% else %}
+        {%- else -%}
             {{ echo_set('localized_time_format', builder.generator.TwigParams.localized_datetime_format) }}
-        {% endif %}
+        {%- endif -%}
+        {%- if column.formOptions.format is defined -%}
+            {{ echo_set('datetime_format', column.formOptions.format) }}
+        {%- else -%}
+            {{ echo_set('datetime_format', builder.generator.TwigParams.datetime_format) }}
+        {%- endif -%}
 
-        {{- echo_twig(builder.ModelClass ~ '.' ~ column.getter ~ '|localizeddate(localized_date_format, localized_time_format)') -}}
+        {{ echo_twig(builder.ModelClass ~ '.' ~ column.getter ~ '|localizeddate(localized_date_format, localized_time_format, null, null, datetime_format)') }}
     {{ echo_endif() }}
 {%- else -%}
     {{ echo_if (builder.ModelClass ~ '.' ~ column.getter) }}
-        {% if column.formOptions.datetime_format is defined %}
-            {{ echo_set('datetime_format', column.formOptions.datetime_format) }}
+        {% if column.formOptions.format is defined %}
+            {{ echo_set('datetime_format', column.formOptions.format) }}
         {% else %}
             {{ echo_set('datetime_format', builder.generator.TwigParams.datetime_format) }}
         {% endif %}
 
-        {{- echo_twig(builder.ModelClass ~ '.' ~ column.getter ~ '|date(datetime_format)') -}}
+        {{ echo_twig(builder.ModelClass ~ '.' ~ column.getter ~ '|date(datetime_format)') }}
     {{ echo_endif() }}
 {%- endif %}
 {% endspaceless %}


### PR DESCRIPTION
This PR fixes the localized date and introduces a minor BC break (easy to fix):
- instead of `if column.formOptions.datetime_format is defined`
- it checks for `if column.formOptions.format is defined`

The enhancement is that it uses `format` option (which is also used by symfony2's base DATE field) as a pattern for translation.

Now, you can translate your date anyhow you want. For example, you can output it in `MMMM YYYY` format:
`December 2013` (not displaying the days).

Another good thing is that you don't have to do:

``` yaml
params:
    fields:
        mydate:
            addFormOptions:
                format: "Y-m-d"
            date_format: "Y-m-d"
```

Instead simply set the format option:

``` yaml
params:
    fields:
        mydate:
            addFormOptions:
                format: "Y-m-d"
```
