### PR TITLE
Allow `label: false` definition to not display label in form

### DIFF
--- a/Generator/Column.php
+++ b/Generator/Column.php
@@ -4,7 +4,7 @@ namespace Admingenerator\GeneratorBundle\Generator;
 
 /**
  * This class describe a column
- * 
+ *
  * @author cedric Lombardot
  * @author Piotr Gołębiewski <loostro@gmail.com>
  */
@@ -17,7 +17,7 @@ class Column
     protected $sortable;
 
     protected $sortOn;
-    
+
     protected $sortType;
 
     protected $filterOn;
@@ -30,7 +30,7 @@ class Column
 
     protected $getter;
 
-    protected $label;
+    protected $label = null;
 
     protected $help;
 
@@ -73,7 +73,9 @@ class Column
 
     public function getLabel()
     {
-        return $this->label ? $this->label : $this->humanize($this->getName());
+        return false !== $this->label && empty($this->label)
+            ? $this->humanize($this->getName())
+            : $this->label;
     }
 
     public function setLabel($label)


### PR DESCRIPTION
Twig templates allow us to define a label to `false` in order to not display it.

Matter is, until this PR, false and null were treated as the same way (and so it was impossible to hide a label from generators).

This PR fix that.
