### PR TITLE
Add filterType and filterOptions property for Column

### DIFF
--- a/Builder/Admin/FiltersBuilder.php
+++ b/Builder/Admin/FiltersBuilder.php
@@ -40,23 +40,31 @@ class FiltersBuilder extends BaseBuilder
                     )
                 )
             );
-
+            
             $column->setFormType(
-                $this->getFieldGuesser()->getFilterType(
-                    $column->getDbType(),
-                    $columnName
+                $this->getFieldOption(
+                    $column,
+                    'filterType',
+                    $this->getFieldGuesser()->getFilterType(
+                        $column->getDbType(),
+                        $columnName
+                    )
                 )
             );
 
             $column->setFormOptions(
-                $this->getFieldGuesser()->getFilterOptions(
-                    $column->getFormType(),
-                    $column->getDbType(),
-                    $columnName
+                $this->getFieldOption(
+                    $column,
+                    'filterOptions',
+                    $this->getFieldGuesser()->getFilterOptions(
+                        $column->getFormType(),
+                        $column->getDbType(),
+                        $columnName
+                    )
                 )
             );
 
-            //Set the user parameters
+            // Set the user parameters
             $this->setUserColumnConfiguration($column);
 
             $this->addColumn($column);

--- a/Generator/Column.php
+++ b/Generator/Column.php
@@ -28,6 +28,10 @@ class Column
 
     protected $formOptions = array();
 
+    protected $filterType;
+
+    protected $filterOptions = array();
+
     protected $getter;
 
     protected $label = null;
@@ -158,6 +162,16 @@ class Column
         return $this->formType;
     }
 
+    public function setFilterType($filterType)
+    {
+        $this->filterType = $filterType;
+    }
+
+    public function getFilterType()
+    {
+        return $this->filterType;
+    }
+
     public function setFormOptions($formOptions)
     {
         $this->formOptions = $formOptions;
@@ -166,6 +180,16 @@ class Column
     public function getFormOptions()
     {
         return $this->formOptions;
+    }
+
+    public function setFilterOptions($filterOptions)
+    {
+        $this->filterOptions = $filterOptions;
+    }
+
+    public function getFilterOptions()
+    {
+        return $this->filterOptions;
     }
 
     public function setCredentials($credentials)


### PR DESCRIPTION
Proposed change:
- add `filterType` and `filterOptions` to `Generator/Column.php`
- for filtersBuilder, if set, use `filterType` and `filterOptions`
- not set -> fallback to current functionality
  - fieldguesser->getFilterType()
  - fieldguesser->getFilterOptions()

However.. this does not work. I'm still getting my `formType` and `formOptions` (on list filters) instead of `filterType` and `filterOptions`.

@cedriclombardot @sescandell @neoshadybeat any idea why this is not working / what am I missing?
