### PR TITLE
Change span2 to span10 for content in show action

### DIFF
--- a/Resources/templates/CommonAdmin/ShowTemplate/show.php.twig
+++ b/Resources/templates/CommonAdmin/ShowTemplate/show.php.twig
@@ -28,7 +28,7 @@
                     {{- echo_endblock() }}
                     </div>
 
-                    <div class="span2">
+                    <div class="span10">
                         <div class="control-group form_field field_{{ field }}">
                         {{ echo_block('show_column_' ~ column.name) -}}
                             {%- if column.dbType|lower == "boolean" -%}


### PR DESCRIPTION
Boostrap row contains 12 columns. So to get full usage of screen in show action second column should be 10 cells wide not only 2.
