### PR TITLE
Changed getManager to getManagerForClass

### DIFF
--- a/Controller/Doctrine/BaseController.php
+++ b/Controller/Doctrine/BaseController.php
@@ -12,8 +12,4 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
  */
 abstract class BaseController extends Controller
 {
-    protected function getEntityManager()
-    {
-        return $this->get('admingenerator.generator.doctrine')->getFieldGuesser()->getEntityManager();
-    }
 }

--- a/Generator/DoctrineGenerator.php
+++ b/Generator/DoctrineGenerator.php
@@ -49,9 +49,6 @@ class DoctrineGenerator extends Generator
             )
         );
         $generator->setFieldGuesser($this->getFieldGuesser());
-        $generator->fieldGuesser->setEntityManager(
-            $generator->getFromYaml('params.entity_manager', null)
-        );
         $generator->setMustOverwriteIfExists($this->needToOverwrite($generator));
         $generator->setTemplateDirs(
             array_merge(
@@ -146,9 +143,6 @@ class DoctrineGenerator extends Generator
             )
         );
         $embedGenerator->setFieldGuesser($this->getFieldGuesser());
-        $embedGenerator->fieldGuesser->setEntityManager(
-            $generator->getFromYaml('params.entity_manager', null)
-        );
         $embedGenerator->setMustOverwriteIfExists($this->needToOverwrite($embedGenerator));
         $embedGenerator->setTemplateDirs(
             array_merge(

--- a/Guesser/DoctrineORMFieldGuesser.php
+++ b/Guesser/DoctrineORMFieldGuesser.php
@@ -11,8 +11,6 @@ class DoctrineORMFieldGuesser extends ContainerAware
 {
     private $doctrine;
 
-    private $entityManager;
-
     private $metadata;
 
     private static $current_class;
@@ -20,16 +18,6 @@ class DoctrineORMFieldGuesser extends ContainerAware
     public function __construct(Registry $doctrine)
     {
         $this->doctrine = $doctrine;
-    }
-
-    public function setEntityManager($manager = null)
-    {
-        $this->entityManager = $this->doctrine->getManager($manager);
-    }
-
-    public function getEntityManager()
-    {
-        return $this->entityManager;
     }
 
     protected function getMetadatas($class = null)
@@ -42,8 +30,8 @@ class DoctrineORMFieldGuesser extends ContainerAware
             return $this->metadata[self::$current_class];
         }
 
-        if (!$this->entityManager->getConfiguration()->getMetadataDriverImpl()->isTransient($class)) {
-            $this->metadata[self::$current_class] = $this->entityManager->getClassMetadata($class);
+        if (!$this->doctrine->getManagerForClass(self::$current_class)->getConfiguration()->getMetadataDriverImpl()->isTransient($class)) {
+            $this->metadata[self::$current_class] = $this->doctrine->getManagerForClass(self::$current_class)->getClassMetadata($class);
         }
 
         return $this->metadata[self::$current_class];

--- a/Resources/doc/generator/entity-manager.md
+++ b/Resources/doc/generator/entity-manager.md
@@ -7,28 +7,8 @@
 
 ### 1. Usage
 
-This option allows you to use another Doctrine ORM Entity Manager than the default
-by suppling the option in the generator.yml.
+When using Doctrine ORM, all Managers are auto-selected by the use of getManagerForClass of Doctrine. 
 
 ### 2. Support
 
-Multiple Entity Managers are only implemented for **Doctrine ORM**.
-
-### 3. Syntax
-
-Usage for the default Entity Manager
-```yaml
-generator:            admingenerator.generator.doctrine
-params:
-  model:              Acme\GalleryBundle\Entity\Album
-  entity_manager: ~                   # use the default Entity Manager from app/config.yml
-```
-
-Usage for an self-defined Entity Manager
-```yaml
-generator:            admingenerator.generator.doctrine
-params:
-  model:              Acme\GalleryBundle\Entity\Album
-  entity_manager:     frontend        # use the "frontend" Entity Manager
-  fields: ~
-```
+Multiple Entity Managers are only automatically implemented for **Doctrine ORM**.

--- a/Resources/skeleton/bundle/generator.yml
+++ b/Resources/skeleton/bundle/generator.yml
@@ -2,7 +2,6 @@ generator: {{ generator }}
 params:
     model: {{ namespace }}\{{ model_folder }}\{{ model_name }}
     namespace_prefix: {{ namespace_prefix }}
-    entity_manager: ~
     concurrency_lock: ~
     bundle_name: {{ bundle_name }}
     pk_requirement: ~

--- a/Resources/templates/Doctrine/ActionsBuilderAction.php.twig
+++ b/Resources/templates/Doctrine/ActionsBuilderAction.php.twig
@@ -5,7 +5,7 @@
     protected function getObject($pk)
     {
         ${{ builder.ModelClass }} = $this->getDoctrine()
-             ->getManager({% if (entity_manager is defined) and (entity_manager != null) %}'{{ entity_manager }}'{% endif %})
+             ->getManagerForClass('{{ model }}')
              ->getRepository('{{ model }}')
              ->find($pk);
 
@@ -22,7 +22,7 @@
     
     protected function executeObjectDelete(\{{ model }} ${{ builder.ModelClass }})
     {
-        $em = $this->getDoctrine()->getManager({% if (entity_manager is defined) and (entity_manager != null) %}'{{ entity_manager }}'{% endif %});
+        $em = $this->getDoctrine()->getManagerForClass('{{ model }}');
         $em->remove(${{ builder.ModelClass }});
         $em->flush();
         $em->clear();
@@ -34,7 +34,7 @@
     
     protected function executeBatchDelete(array $selected)
     {
-        $this->getDoctrine()->getManager({% if (entity_manager is defined) and (entity_manager != null) %}'{{ entity_manager }}'{% endif %})
+        $this->getDoctrine()->getManagerForClass('{{ model }}')
             ->createQuery('DELETE {{ model }} m WHERE m.{{ builder.getFieldGuesser().getModelPrimaryKeyName(model) }} IN (:selected)')
             ->setParameter('selected', $selected)
             ->getResult();

--- a/Resources/templates/Doctrine/EditBuilderAction.php.twig
+++ b/Resources/templates/Doctrine/EditBuilderAction.php.twig
@@ -9,7 +9,7 @@ use Doctrine\ORM\OptimisticLockException;
     protected function getObject($pk)
     {
         return $this->getDoctrine()
-                    ->getManager({{ entity_manager|default('')|wrap('"') }})
+                    ->getManagerForClass('{{ model }}')
                     ->getRepository('{{ model }}')
                     ->find($pk);
     }
@@ -18,14 +18,14 @@ use Doctrine\ORM\OptimisticLockException;
 {% block saveObject -%}
     protected function saveObject(\{{ model }} ${{ builder.ModelClass }})
     {
-        $em = $this->getDoctrine()->getManager({{ entity_manager|default('')|wrap('"') }});
+        $em = $this->getDoctrine()->getManagerForClass('{{ model }}');
         $em->persist(${{ builder.ModelClass }});
         $em->flush();
     }
 {% endblock %}
 
 {% block checkVersion -%}
-    $this->getDoctrine()->getManager({{ entity_manager|default('')|wrap('"') }})->lock(${{ builder.ModelClass }}, LockMode::OPTIMISTIC, $versions[$pk]);
+    $this->getDoctrine()->getManagerForClass('{{ model }}')->lock(${{ builder.ModelClass }}, LockMode::OPTIMISTIC, $versions[$pk]);
 {% endblock %}
 
 {% block lockException %}OptimisticLockException{% endblock %}

--- a/Resources/templates/Doctrine/ListBuilderAction.php.twig
+++ b/Resources/templates/Doctrine/ListBuilderAction.php.twig
@@ -38,7 +38,9 @@
             {%- if 'entity' == builder.getFieldGuesser().getDbType(model, filter) or 'collection' == builder.getFieldGuesser().getDbType(model, filter) -%}
 
         if (isset($filters['{{ filter }}'])) {
-                $filters['{{ filter }}'] = $this->getDoctrine()->getRepository($filters['{{ filter }}']['entityName'])->find($filters['{{ filter }}']['id']);
+                $filters['{{ filter }}'] = $this->getDoctrine()
+                ->getManagerForClass($filters['{{ filter }}']['entityName'])
+                ->getRepository($filters['{{ filter }}']['entityName'])->find($filters['{{ filter }}']['id']);
         }
 
             {%- endif %}

--- a/Resources/templates/Doctrine/NestedListBuilderAction.php.twig
+++ b/Resources/templates/Doctrine/NestedListBuilderAction.php.twig
@@ -15,7 +15,7 @@
     protected function buildQuery()
     {
         return $this->getDoctrine()
-                    ->getManager({% if (entity_manager is defined) and (entity_manager != null) %}'{{ entity_manager }}'{% endif %})
+                    ->getManagerForClass('{{ model }}')
                     ->getRepository('{{ model }}')
                     ->getChildrenQueryBuilder()
                     ->add('orderBy', 'node.{{ builder.treeConfiguration.root }} ASC, node.{{ builder.treeConfiguration.left }} ASC')
@@ -39,7 +39,7 @@
             {%- if 'entity' == builder.getFieldGuesser().getDbType(model, filter) or 'collection' == builder.getFieldGuesser().getDbType(model, filter) -%}
 
         if (isset($filters['{{ filter }}'])) {
-            $this->getDoctrine()->getManager({% if (entity_manager is defined) and (entity_manager != null) %}'{{ entity_manager }}'{% endif %})->getUnitOfWork()->registerManaged($filters['{{ filter }}'], array('id' => $filters['{{ filter }}']->getId()), array());
+            $this->getDoctrine()->getManagerForClass('{{ model }}')->getUnitOfWork()->registerManaged($filters['{{ filter }}'], array('id' => $filters['{{ filter }}']->getId()), array());
         }
 
             {%- endif %}
@@ -114,7 +114,7 @@
             throw new NotFoundHttpException("Unknown action");
         }
 
-        $em = $this->getDoctrine()->getManager({% if (entity_manager is defined) and (entity_manager != null) %}'{{ entity_manager }}'{% endif %});
+        $em = $this->getDoctrine()->getManagerForClass('{{ model }}');
         $repo = $em->getRepository('{{ model }}');
 
         $dragged = $repo->findOneBy{{ builder.getFieldGuesser().getModelPrimaryKeyName(model)|classify }}($dragged);

--- a/Resources/templates/Doctrine/NewBuilderAction.php.twig
+++ b/Resources/templates/Doctrine/NewBuilderAction.php.twig
@@ -3,7 +3,7 @@
 {% block saveObject -%}
     protected function saveObject(\{{ model }} ${{ builder.ModelClass }})
     {
-        $em = $this->getDoctrine()->getManager({{ entity_manager|default('')|wrap('"') }});
+        $em = $this->getDoctrine()->getManagerForClass('{{ model }}');
         $em->persist(${{ builder.ModelClass }});
         $em->flush();
     }

--- a/Resources/templates/Doctrine/ShowBuilderAction.php.twig
+++ b/Resources/templates/Doctrine/ShowBuilderAction.php.twig
@@ -3,7 +3,7 @@
     protected function getObject($pk)
     {
         return $this->getDoctrine()
-                    ->getManager({% if (entity_manager is defined) and (entity_manager != null) %}'{{ entity_manager }}'{% endif %})
+                    ->getManagerForClass('{{ model }}')
                     ->getRepository('{{ model }}')
                     ->find($pk);
     }


### PR DESCRIPTION
I've found this method today, as I was looking into a filter issue (when not using the default EntityManager, filtering on relations did not work, as the entity was not in the configured chain). 

This should fix all Doctrine ORM entitymanager problems. Also removed the getEntityManager function in the BaseController, I could not find any piece of code that uses it.

```
Changed the EntityManager for Doctrine ORM to getManagerForClass to make the code better understandable.

Removed the getEntityManager() function from the ORM BaseController, as it appears not to be used anywhere in the code.
```
