### PR TITLE
add class comment to DefaultController/Type for fixing coding standard

### DIFF
--- a/Resources/skeleton/bundle/DefaultController.php
+++ b/Resources/skeleton/bundle/DefaultController.php
@@ -4,6 +4,9 @@ namespace {{ namespace }}\Controller{{ prefix ? "\\" ~ prefix : "" }};
 
 use Admingenerated\{{ bundle }}\Base{{ prefix }}Controller\{{ action }}Controller as Base{{ action }}Controller;
 
+/**
+ * {{ action }}Controller
+ */
 class {{ action }}Controller extends Base{{ action }}Controller
 {
 }

--- a/Resources/skeleton/bundle/DefaultType.php
+++ b/Resources/skeleton/bundle/DefaultType.php
@@ -4,6 +4,9 @@ namespace {{ namespace }}\Form\Type{{ prefix ? "\\" ~ prefix : "" }};
 
 use Admingenerated\{{ bundle }}\Form\Base{{ prefix }}Type\{{ form }}Type as Base{{ form }}Type;
 
+/**
+ * {{ form }}Type
+ */
 class {{ form }}Type extends Base{{ form }}Type
 {
 }


### PR DESCRIPTION
After entity generation, it will fix coding standard : 

```
ERROR   | Missing class doc comment
```
