### PR TITLE
Fix: restrict bootstrap component to a version inferior to 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "afarkas/html5shiv": "dev-master",
         "components/jquery": ">= 1.9.0, < 2.0.0",
         "components/jqueryui": ">= 1.9.0",
-        "components/bootstrap": ">= 2.3.1",
+        "components/bootstrap": ">= 2.3.1,<3.0.0",
         "components/font-awesome": ">= 3.2.0"
     },
     "require-dev": {


### PR DESCRIPTION
This fixes the issue #643
