### PR TITLE
Fixed preg_match

### DIFF
--- a/Twig/Extension/EchoExtension.php
+++ b/Twig/Extension/EchoExtension.php
@@ -117,7 +117,7 @@ class EchoExtension extends \Twig_Extension
         }
 
         if (preg_match('#^(.+)Type$#i', $formType) || 'form_widget'== $formType) { // For type wich are not strings
-            preg_match("/\'(.*)Type/", $options, $matches);
+            preg_match("/\'(.*)Type\'/", $options, $matches);
 
             if (count($matches) > 0) {
                 return 'new '.stripslashes($matches[1]).'Type()';


### PR DESCRIPTION
Another quick fix for #650.

We should be sure that the checked option ends with Type. 
Without that such configuration in *-generator.yml:

``` yml
page:
        label: ""
        formType: \NS\AdminBundle\Form\Type\BasePage\EditType
        addFormOptions:
          data_class: NS\CMSBundle\Model\Page\TeaTypePage
```

will generate such code:

``` php
$formOptions = $this->getFormOption('page', new required' => false,  'data_class' => 'NS\CMSBundle\Model\Page\TeaType());
```

and of course fatal error.
