### PR TITLE
Allow generic actions to use ACL

### DIFF
--- a/Resources/templates/CommonAdmin/generic_actions.php.twig
+++ b/Resources/templates/CommonAdmin/generic_actions.php.twig
@@ -4,7 +4,7 @@
         {% for action in builder.Actions %}
             {{ echo_block("generic_action_" ~ action.twigName) }}
             {% if action.credentials or builder.generator.getFromYaml('builders.' ~ action.name ~ '.params.credentials') %}
-                {{ echo_if_granted(action.credentials ? action.credentials : builder.generator.getFromYaml('builders.' ~ action.name ~ '.params.credentials') ) }}
+                {{ echo_if_granted(action.credentials ? action.credentials : builder.generator.getFromYaml('builders.' ~ action.name ~ '.params.credentials'), builder.ModelClass ) }}
             {% endif %}
 
                 {% if action.conditionalFunction %}


### PR DESCRIPTION
Fixes a problem if f.e. there are credentials on the show action in the form of hasPermission(object, "VIEW"). If this is then used in the edit view an error is thrown because the object isn't passed.
