### PR TITLE
updates doc for costumizing the navbar menu

### DIFF
--- a/Resources/doc/cookbook/menu.md
+++ b/Resources/doc/cookbook/menu.md
@@ -36,9 +36,11 @@ To overwrite this, you need to [create][create-builder] a new menu builder class
 To make things easier Admingenerator ships a [base][extend-builder] class which 
 you can extend (see [default][default-builder] menu builder to an example).
 
-> **Note**: To extend the base menu builder, you own menu builder has to be defined as a service.
+> **Note**: In case of extending the default builder, your own menu builder has to be defined as a service (see 
+[Creating Menus as Services][create-service-builder]).
 
 [create-builder]: https://github.com/KnpLabs/KnpMenuBundle/blob/master/Resources/doc/index.md#method-a-the-easy-way-yay
+[create-service-builder]: https://github.com/KnpLabs/KnpMenuBundle/blob/master/Resources/doc/menu_service.md
 [extend-builder]: https://github.com/symfony2admingenerator/AdmingeneratorGeneratorBundle/blob/master/Menu/AdmingeneratorMenuBuilder.php
 [default-builder]: https://github.com/symfony2admingenerator/AdmingeneratorGeneratorBundle/blob/master/Menu/DefaultMenuBuilder.php
 


### PR DESCRIPTION
in case of extending the base menu builder, the own menu builder has to be defined as a service. otherwise you get a fatal error because of type mismatch in constructor-method.
