### PR TITLE
Fix warning when using config:dump-reference on admingenerator_generator

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -319,7 +319,7 @@ class Configuration implements ConfigurationInterface
                     ->scalarNode('path')->end()
                     ->scalarNode('route')->end()
                     ->arrayNode('routeparams')
-                        ->useAttributeAsKey(array('key'))
+                        ->useAttributeAsKey('key')
                         ->prototype('scalar')
                         ->end()
                     ->end()


### PR DESCRIPTION
Fix warning when using config:dump-reference on admingenerator_generator
