### PR TITLE
Adds a badge to tabs with :invalid form fields

### DIFF
--- a/Resources/templates/CommonAdmin/tabs.php.twig
+++ b/Resources/templates/CommonAdmin/tabs.php.twig
@@ -15,6 +15,15 @@
         ;(function(window, $, undefined){
             $(function() {
                 $('.form_tabs.nav.nav-tabs a:first').tab('show');
+                $('input[type=submit],button[type=submit]').on('click', function(e){
+                    $('.form_tabs.nav.nav-tabs li').each(function(i){
+                        $(this).find('a span.badge-important').remove();
+                        invalid_items = $('fieldset'+$(this).find('a:first').data('target')).find(':invalid');
+                        if(invalid_items.length>0){
+                            $(this).find('a:first').append('<span class="badge badge-important">'+invalid_items.length+'</span>');
+                        }
+                    });
+                });          
             });
         })(this, jQuery);
     </script>


### PR DESCRIPTION
When submitting a form with html5 validation on in Chrome, there is a javascript error in the console if the form field with an error is in another tab than the currently visible tab, giving no indication to the user (except the error in the javascript console).

This commit adds a click handler to the submit button, adding badges to tabs with form fields containing errors, making it easier for the user to correct their errors to properly submit the form.
