### PR TITLE
DoctrineORMFieldGuesser - ManyToMany relations

### DIFF
--- a/Guesser/DoctrineORMFieldGuesser.php
+++ b/Guesser/DoctrineORMFieldGuesser.php
@@ -144,7 +144,7 @@ class DoctrineORMFieldGuesser extends ContainerAware
             $mapping = $this->getMetadatas()->getAssociationMapping($columnName);
 
             return array(
-                'multiple'  => false,
+                'multiple'  => ($mapping['type'] === ClassMetadataInfo::MANY_TO_MANY),
                 'em'        => 'default', // TODO: shouldn't this be configurable?
                 'class'     => $mapping['targetEntity'],
                 'required'  => $this->isRequired($columnName),


### PR DESCRIPTION
When using the `avocode/form-extensions-bundle` to use a double_list on a ManyToMany Doctrine relation, the generated formOptions was not correct : the `multiple` formOption was set to `false` and the entity could not be saved correctly.

I added a test on the relation type in the DoctrineORMFieldGuesser to set `multiple` to `true` in the case of a ManyToMany relation.

My tests were made with the following config:

```
admingenerator_generator:
    form_types:
        doctrine_orm:
            collection:   double_list_entity
```

Do you think this fix is correct ?
