### PR TITLE
Fixing error in PR #676

### DIFF
--- a/Guesser/DoctrineORMFieldGuesser.php
+++ b/Guesser/DoctrineORMFieldGuesser.php
@@ -5,6 +5,7 @@ namespace Admingenerator\GeneratorBundle\Guesser;
 use Admingenerator\GeneratorBundle\Exception\NotImplementedException;
 
 use Doctrine\Bundle\DoctrineBundle\Registry;
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Symfony\Component\DependencyInjection\ContainerAware;
 
 class DoctrineORMFieldGuesser extends ContainerAware


### PR DESCRIPTION
There was a missing `use` in PR #676.

As it has already been merged, I'm submitting a new one.

Sorry about that...
