### PR TITLE
DoctrineORMFieldGuesser - OneToMany relations

### DIFF
--- a/Guesser/DoctrineORMFieldGuesser.php
+++ b/Guesser/DoctrineORMFieldGuesser.php
@@ -145,7 +145,7 @@ class DoctrineORMFieldGuesser extends ContainerAware
             $mapping = $this->getMetadatas()->getAssociationMapping($columnName);
 
             return array(
-                'multiple'  => ($mapping['type'] === ClassMetadataInfo::MANY_TO_MANY),
+                'multiple'  => ($mapping['type'] === ClassMetadataInfo::MANY_TO_MANY || $mapping['type'] === ClassMetadataInfo::ONE_TO_MANY),
                 'em'        => 'default', // TODO: shouldn't this be configurable?
                 'class'     => $mapping['targetEntity'],
                 'required'  => $this->isRequired($columnName),


### PR DESCRIPTION
This is related to #676 that fixed the `multiple` formOption value in the case of ManyToMany relations.

This PR also set to this option to `true` in the case of OneToMany relations.
