### PR TITLE
add getQueryFilter to list builder action

### DIFF
--- a/Resources/templates/CommonAdmin/ListAction/ListBuilderAction.php.twig
+++ b/Resources/templates/CommonAdmin/ListAction/ListBuilderAction.php.twig
@@ -47,7 +47,7 @@ class ListController extends BaseController
     {
         return array();
     }
-    
+
     /**
      * This function is for your convinience. Overwrite it if you need to
      * process the query.
@@ -108,4 +108,12 @@ class ListController extends BaseController
 
         return $type;
     }
+
+    {% block getQueryFilter -%}
+    protected function getQueryFilter()
+    {
+        // ORM JOB
+    }
+    {% endblock %}
+
 }

--- a/Resources/templates/Doctrine/ListBuilderAction.php.twig
+++ b/Resources/templates/Doctrine/ListBuilderAction.php.twig
@@ -66,7 +66,7 @@
 
     protected function buildQuery()
     {
-        return $this->getDoctrine()                    
+        return $this->getDoctrine()
                     ->getManagerForClass('{{ model }}')
                     ->getRepository('{{ model }}')
                     ->createQueryBuilder('q');
@@ -123,12 +123,12 @@
     {
         $filterObject = $this->getFilters();
 
-        $queryFilter = $this->get('admingenerator.queryfilter.doctrine');
+        $queryFilter = $this->getQueryFilter();
         $queryFilter->setQuery($query);
 
         {% for filter in builder.filterColumns %}
             if (isset($filterObject['{{ filter.name }}']) && null !== $filterObject['{{ filter.name }}']) {
-                $queryFilter->add{{ filter.dbType|classify }}Filter("{{ filter.filterOn }}", $filterObject['{{ filter.name }}']);
+                $queryFilter->add{{ filter.dbType|classify }}Filter('{{ filter.filterOn }}', $filterObject['{{ filter.name }}']);
             }
         {% endfor %}
 
@@ -141,7 +141,7 @@
     {% if scopes is defined %}
         $scopes = $this->getScopes();
 
-        $queryFilter = $this->get('admingenerator.queryfilter.doctrine');
+        $queryFilter = $this->getQueryFilter();
         $queryFilter->setQuery($query);
 
 
@@ -154,7 +154,7 @@
                 {%- if filter|is_numeric -%}
                 $this->scope{{ filterParams|classify }}($queryFilter);
                 {%- else -%}
-                $queryFilter->addDefaultFilter("{{ filter }}", {{ filterParams|as_php }});
+                $queryFilter->addDefaultFilter('{{ filter }}', {{ filterParams|as_php }});
                 {%- endif -%}
                 {%- endfor -%}
             {%- endif %}
@@ -172,10 +172,10 @@
             {%- for filter, filterParams in params["filters"] -%}
                 {%- if filter|is_numeric -%}
     /**
-    * Add the filters to the query for {{ groupName }} => {{ scopeName }}
-    *
-    * @param queryFilter the queryFilter
-    */
+     * Add the filters to the query for {{ groupName }} => {{ scopeName }}
+     *
+     * @param queryFilter the queryFilter
+     */
     protected function scope{{ filterParams|classify }}($query)
     {
     }
@@ -186,4 +186,14 @@
         {% endfor -%}
     {%- endfor -%}
     {%- endif %}
+{% endblock %}
+
+{% block getQueryFilter %}
+    /**
+     * @return \Admingenerator\GeneratorBundle\QueryFilter\QueryFilterInterface
+     */
+    protected function getQueryFilter()
+    {
+        return $this->get('admingenerator.queryfilter.doctrine');
+    }
 {% endblock %}

--- a/Resources/templates/DoctrineODM/ListBuilderAction.php.twig
+++ b/Resources/templates/DoctrineODM/ListBuilderAction.php.twig
@@ -120,13 +120,13 @@ use Pagerfanta\Adapter\DoctrineODMMongoDBAdapter as PagerAdapter;
     {
         $filterObject = $this->getFilters();
 
-        $queryFilter = $this->get('admingenerator.queryfilter.doctrine_odm');
+        $queryFilter = $this->getQueryFilter();
         $queryFilter->setQuery($query);
 
         {% for filter in builder.filterColumns %}
 
         if (isset($filterObject['{{ filter.name }}']) && null !== $filterObject['{{ filter.name }}']) {
-            $queryFilter->add{{ filter.dbType|classify }}Filter("{{ filter.filterOn }}", $filterObject['{{ filter.name }}']);
+            $queryFilter->add{{ filter.dbType|classify }}Filter('{{ filter.filterOn }}', $filterObject['{{ filter.name }}']);
         }
         {% endfor %}
 
@@ -139,7 +139,7 @@ use Pagerfanta\Adapter\DoctrineODMMongoDBAdapter as PagerAdapter;
     {% if scopes is defined -%}
         $scopes = $this->getScopes();
 
-        $queryFilter = $this->get('admingenerator.queryfilter.doctrine_odm');
+        $queryFilter = $this->getQueryFilter();
         $queryFilter->setQuery($query);
 
 
@@ -152,7 +152,7 @@ use Pagerfanta\Adapter\DoctrineODMMongoDBAdapter as PagerAdapter;
                 {%- if filter|is_numeric -%}
                 $this->scope{{ filterParams|classify }}($queryFilter);
                 {%- else -%}
-                $queryFilter->addDefaultFilter("{{ filter }}", {{ filterParams|as_php }});
+                $queryFilter->addDefaultFilter('{{ filter }}', {{ filterParams|as_php }});
                 {%- endif -%}
                 {%- endfor -%}
             {%- endif %}
@@ -170,18 +170,27 @@ use Pagerfanta\Adapter\DoctrineODMMongoDBAdapter as PagerAdapter;
             {%- for filter, filterParams in params["filters"] -%}
                 {%- if filter|is_numeric -%}
     /**
-    * Add the filters to the query for {{ groupName }} => {{ scopeName }}
-    *
-    * @param queryFilter the queryFilter
-    */
+     * Add the filters to the query for {{ groupName }} => {{ scopeName }}
+     *
+     * @param queryFilter the queryFilter
+     */
     protected function scope{{ filterParams|classify }}($query)
     {
     }
-
                 {%- endif -%}
             {%- endfor -%}
             {%- endif -%}
         {% endfor -%}
     {%- endfor -%}
     {%- endif %}
+{% endblock %}
+
+{% block getQueryFilter %}
+    /**
+     * @return \Admingenerator\GeneratorBundle\QueryFilter\QueryFilterInterface
+     */
+    protected function getQueryFilter()
+    {
+        return $this->get('admingenerator.queryfilter.doctrine_odm');
+    }
 {% endblock %}

--- a/Resources/templates/Propel/ListBuilderAction.php.twig
+++ b/Resources/templates/Propel/ListBuilderAction.php.twig
@@ -57,13 +57,13 @@ use Pagerfanta\Adapter\PropelAdapter as PagerAdapter;
     {
         $filterObject = $this->getFilters();
 
-        $queryFilter = $this->get('admingenerator.queryfilter.propel');
+        $queryFilter = $this->getQueryFilter();
         $queryFilter->setQuery($query);
 
         {% for filter in builder.filterColumns %}
 
         if (isset($filterObject['{{ filter.name }}']) && null !== $filterObject['{{ filter.name }}']) {
-            $queryFilter->add{{ filter.dbType|lower|classify }}Filter("{{ filter.filterOn }}", $filterObject['{{ filter.name }}']);
+            $queryFilter->add{{ filter.dbType|lower|classify }}Filter('{{ filter.filterOn }}', $filterObject['{{ filter.name }}']);
         }
         {% endfor %}
 
@@ -94,5 +94,15 @@ use Pagerfanta\Adapter\PropelAdapter as PagerAdapter;
             {% endfor -%}
         {%- endfor %}
     {% endif %}
+    }
+{% endblock %}
+
+{% block getQueryFilter %}
+    /**
+     * @return \Admingenerator\GeneratorBundle\QueryFilter\QueryFilterInterface
+     */
+    protected function getQueryFilter()
+    {
+        return $this->get('admingenerator.queryfilter.propel');
     }
 {% endblock %}


### PR DESCRIPTION
I added this function, because I wrote my own query filter. Without this patch I must copy the complete method processFilters() or processScoupes(). Now I overwrite only the getQueryFilter method.
