### PR TITLE
Fixing incorrect usage of the Doctrine ODM query builder

### DIFF
--- a/Resources/templates/DoctrineODM/ActionsBuilderAction.php.twig
+++ b/Resources/templates/DoctrineODM/ActionsBuilderAction.php.twig
@@ -11,7 +11,7 @@
     protected function getObject($pk)
     {
         $pk = is_numeric($pk) ? intval($pk) : $pk;
-        ${{ builder.ModelClass }} = $this->getObjectQuery($pk)->getOneOrNullResult();
+        ${{ builder.ModelClass }} = $this->getObjectQuery($pk)->getSingleResult();
 
         if (!${{ builder.ModelClass }}) {
             throw new \InvalidArgumentException("No {{ model }} found on {{ builder.getFieldGuesser().getModelPrimaryKeyName(model) }} : $pk");

--- a/Resources/templates/DoctrineODM/ShowBuilderAction.php.twig
+++ b/Resources/templates/DoctrineODM/ShowBuilderAction.php.twig
@@ -11,7 +11,7 @@
     {
         $pk = is_numeric($pk) ? intval($pk) : $pk;
 
-        return $this->getQuery($pk)->getOneOrNullResult();
+        return $this->getQuery($pk)->getSingleResult();
     }
 {% endblock %}
 


### PR DESCRIPTION
Code must have been copied over from the the Doctrine ORM, as it was using that style. I've corrected this for ODM templates.
