### PR TITLE
Removed unused code which generates PHP warnings

### DIFF
--- a/Resources/templates/CommonAdmin/ExcelAction/ExcelBuilderAction.php.twig
+++ b/Resources/templates/CommonAdmin/ExcelAction/ExcelBuilderAction.php.twig
@@ -80,10 +80,6 @@ class ExcelController extends ListController
           $sheet->setCellValueByColumnAndRow({{ column }}, $row, $rowData->get{{ builder_column.getter|capitalize }}());
           {% set column = column + 1 %}
         {% endfor %}
-        foreach($rowData as $columnData){
-          $sheet->setCellValueByColumnAndRow($column, $row, $columnData);
-          $column++;
-        }
         $row++;
       }
     }


### PR DESCRIPTION
I've discovered some unused code in the Excel export (I recently enabled the real Debug option of Symfony). 

Please merge :+1: 
