### PR TITLE
Fixes a problem when using safe labels in knp

### DIFF
--- a/Resources/views/KnpMenu/knp_menu_trans.html.twig
+++ b/Resources/views/KnpMenu/knp_menu_trans.html.twig
@@ -1,6 +1,7 @@
 {% extends 'knp_menu.html.twig' %}
 {% block label %}
     {% if item.getExtra('icon') is defined %}<i class="{{ item.getExtra('icon') }}"></i>{% endif %}
-    {{ item.label|trans(item.getExtra('translation_params', {}), item.getExtra('translation_domain', 'messages')) }}
+    {% set labelText = item.label|trans(item.getExtra('translation_params', {}), item.getExtra('translation_domain', 'messages')) %}
+    {% if options.allow_safe_labels and item.getExtra('safe_label', false) %}{{ labelText|raw }}{% else %}{{ labelText }}{% endif %}
     {% if item.getExtra('caret') %}<b class="caret"></b>{% endif %}
 {% endblock %}


### PR DESCRIPTION
Allows to use allow_safe_labels and safe_label from the KNP menu
