### PR TITLE
Added realpath to dirname usages

### DIFF
--- a/Command/GenerateAdminAdminCommand.php
+++ b/Command/GenerateAdminAdminCommand.php
@@ -90,7 +90,7 @@ EOT
         $input->setOption('bundle-name', $bundle);
 
         // target dir
-        $dir = $input->getOption('dir') ?: dirname($this->getContainer()->getParameter('kernel.root_dir')).'/src';
+        $dir = $input->getOption('dir') ?: dirname(realpath($this->getContainer()->getParameter('kernel.root_dir'))).'/src';
         $output->writeln(array(
             '',
             'The bundle can be generated anywhere. The suggested default directory uses',

--- a/Routing/Manipulator/RoutingManipulator.php
+++ b/Routing/Manipulator/RoutingManipulator.php
@@ -60,7 +60,7 @@ class RoutingManipulator extends Manipulator
             if (false !== strpos($current, $routing_name)) {
                 throw new \RuntimeException(sprintf('Bundle "%s" is already imported.', $bundle));
             }
-        } elseif (!is_dir($dir = dirname($this->file))) {
+        } elseif (!is_dir($dir = dirname(realpath($this->file)))) {
             mkdir($dir, 0777, true);
         }
 


### PR DESCRIPTION
This should solve every issue which might happen as described in #750. By first calculating the real path (see http://www.php.net/manual/en/function.realpath.php) the dirname function should always return the parent dir (and not just remove the last `../`). 
#750 can be closed after merge.
