### PR TITLE
FIX: logout fa-power-off icon

### DIFF
--- a/Resources/views/base_admin_navbar.html.twig
+++ b/Resources/views/base_admin_navbar.html.twig
@@ -24,7 +24,7 @@
                         </button>
                         {% endif %}
                         <button type="button" id="button-logout" class="btn btn-sm btn-profile" title="{{ 'profile.logout'|trans({}, 'Admingenerator') }}">
-                            <i class="fa fa-off fa-white"></i>
+                            <i class="fa fa-power-off fa-white"></i>
                         </button>
                     </li>
                     {% endif %}


### PR DESCRIPTION
The fa-off icon does not exist, I guess it should be fa-power-off instead.
