### PR TITLE
(v1.0) Re-organized ExcelBuilderAction.php.twig

### DIFF
--- a/Resources/templates/CommonAdmin/ExcelAction/ExcelBuilderAction.php.twig
+++ b/Resources/templates/CommonAdmin/ExcelAction/ExcelBuilderAction.php.twig
@@ -69,35 +69,52 @@ class ExcelController extends ListController
     }
 
     /**
-     * Fills the Excel spreadsheet with data
+     * Gets the value from the given field that will be place at an Excel cell
+     *
+     * @param string $field   The name of the field to extract the value
+     * @param mixed  $rowData The main entity object
+     *
+     * @return $data The data to place on the respective Excel cell
      */
-    protected function createExcelData(\PhpExcel_Worksheet $sheet){
-      $row = 2;
-      $results = $this->getResults();
-      foreach($results as $rowData){
-        {% set column = 0 %}
-        {% for builder_column in builder.columns %}
-
-          // Retrieve relations
-          $getter = '{{ builder_column.getter }}';
-          $data = $rowData;
-          while (($pos = strpos($getter, '.')) > 0){
-            $tempGetter = 'get' . ucfirst(substr($getter, 0, $pos));
+    protected function getValueForCell($field, $rowData)
+    {
+        $getter = $field;
+        $data = $rowData;
+        // Retrieve relations
+        while (($pos = strpos($getter, '.')) > 0) {
+            $tempGetter = 'get'.ucfirst(substr($getter, 0, $pos));
             $getter = substr($getter, $pos + 1);
             $data = $data->$tempGetter();
-          }
-          $getter = 'get' . ucfirst($getter);
-          $data = $data->$getter();
+        }
+        $getter = 'get'.ucfirst($getter);
+        $data = $data->$getter();
 
-          // Convert DateTime object to given format
-          if ($data instanceof \DateTime){
-            $data = $data->format('{{ builder.dateTimeFormat }}');
-          }
-          $sheet->setCellValueByColumnAndRow({{ column }}, $row, $data);
-          {% set column = column + 1 %}
-        {% endfor %}
-        $row++;
-      }
+        // Convert DateTime object to given format
+        if ($data instanceof \DateTime) {
+            $data = $data->format('d-m-Y H:i:s');
+        }
+
+        return $data;
+    }
+
+    /**
+     * Fills the Excel spreadsheet with data
+     */
+    protected function createExcelData(\PhpExcel_Worksheet $sheet)
+    {
+        $row = 2;
+        $results = $this->getResults();
+        foreach($results as $rowData) {
+          {%- set column = 0 -%}
+          {%- for builder_column in builder.columns %}
+
+            $data = $this->getValueForCell('{{ builder_column.getter }}', $rowData);
+            $sheet->setCellValueByColumnAndRow({{ column }}, $row, $data);
+            {% set column = column + 1 %}
+          {%- endfor %}
+
+            $row++;
+        }
     }
 
     {% block getResults -%}

--- a/Resources/templates/CommonAdmin/ExcelAction/ExcelBuilderAction.php.twig
+++ b/Resources/templates/CommonAdmin/ExcelAction/ExcelBuilderAction.php.twig
@@ -8,6 +8,7 @@ namespace Admingenerated\{{ namespace_prefix }}{{ bundle_name }}\{{ builder.gene
 {{- block('csrf_protection_use') }}
 
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Component\PropertyAccess\PropertyAccess;
 
 /**
  * @author Bob van de Vijver
@@ -83,16 +84,14 @@ class ExcelController extends ListController
      */
     protected function getValueForCell($field, $rowData)
     {
-        $getter = $field;
+        $accessor = PropertyAccess::createPropertyAccessor();
         $data = $rowData;
         // Retrieve relations
-        while (($pos = strpos($getter, '.')) > 0) {
-            $tempGetter = 'get'.ucfirst(substr($getter, 0, $pos));
-            $getter = substr($getter, $pos + 1);
-            $data = is_object($data) ? $data->$tempGetter() : '';
+        while (($pos = strpos($field, '.')) > 0) {
+            $field = substr($field, $pos + 1);
+            $data = $accessor->getValue($data, substr($field, 0, $pos));
         }
-        $getter = 'get'.ucfirst($getter);
-        $data = is_object($data) ? $data->$getter() : '';
+        $data = $accessor->getValue($data, $field);
 
         // Convert DateTime object to given format
         if ($data instanceof \DateTime) {

--- a/Resources/templates/CommonAdmin/ExcelAction/ExcelBuilderAction.php.twig
+++ b/Resources/templates/CommonAdmin/ExcelAction/ExcelBuilderAction.php.twig
@@ -84,10 +84,10 @@ class ExcelController extends ListController
         while (($pos = strpos($getter, '.')) > 0) {
             $tempGetter = 'get'.ucfirst(substr($getter, 0, $pos));
             $getter = substr($getter, $pos + 1);
-            $data = $data->$tempGetter();
+            $data = is_object($data) ? $data->$tempGetter() : '';
         }
         $getter = 'get'.ucfirst($getter);
-        $data = $data->$getter();
+        $data = is_object($data) ? $data->$getter() : '';
 
         // Convert DateTime object to given format
         if ($data instanceof \DateTime) {

--- a/Resources/templates/CommonAdmin/ExcelAction/ExcelBuilderAction.php.twig
+++ b/Resources/templates/CommonAdmin/ExcelAction/ExcelBuilderAction.php.twig
@@ -89,10 +89,10 @@ class ExcelController extends ListController
         while (($pos = strpos($getter, '.')) > 0) {
             $tempGetter = 'get'.ucfirst(substr($getter, 0, $pos));
             $getter = substr($getter, $pos + 1);
-            $data = $data->$tempGetter();
+            $data = is_object($data) ? $data->$tempGetter() : '';
         }
         $getter = 'get'.ucfirst($getter);
-        $data = $data->$getter();
+        $data = is_object($data) ? $data->$getter() : '';
 
         // Convert DateTime object to given format
         if ($data instanceof \DateTime) {

--- a/Resources/templates/CommonAdmin/ExcelAction/ExcelBuilderAction.php.twig
+++ b/Resources/templates/CommonAdmin/ExcelAction/ExcelBuilderAction.php.twig
@@ -108,7 +108,11 @@ class ExcelController extends ListController
           {%- set column = 0 -%}
           {%- for builder_column in builder.columns %}
 
-            $data = $this->getValueForCell('{{ builder_column.getter }}', $rowData);
+            if (method_exists($this, 'format{{ (builder_column.getter|classify)|php_name }}Value')) {
+                $data = $this->format{{ (builder_column.getter|classify)|php_name }}Value($rowData);
+            } else {
+                $data = $this->getValueForCell('{{ builder_column.getter }}', $rowData);
+            }
             $sheet->setCellValueByColumnAndRow({{ column }}, $row, $data);
             {% set column = column + 1 %}
           {%- endfor %}

--- a/Resources/templates/CommonAdmin/ExcelAction/ExcelBuilderAction.php.twig
+++ b/Resources/templates/CommonAdmin/ExcelAction/ExcelBuilderAction.php.twig
@@ -91,7 +91,7 @@ class ExcelController extends ListController
 
         // Convert DateTime object to given format
         if ($data instanceof \DateTime) {
-            $data = $data->format('d-m-Y H:i:s');
+            $data = $data->format('{{ builder.dateTimeFormat }}');
         }
 
         return $data;

--- a/Resources/templates/CommonAdmin/ExcelAction/ExcelBuilderAction.php.twig
+++ b/Resources/templates/CommonAdmin/ExcelAction/ExcelBuilderAction.php.twig
@@ -113,7 +113,11 @@ class ExcelController extends ListController
           {%- set column = 0 -%}
           {%- for builder_column in builder.columns %}
 
-            $data = $this->getValueForCell('{{ builder_column.getter }}', $rowData);
+            if (method_exists($this, 'format{{ (builder_column.getter|classify)|php_name }}Value')) {
+                $data = $this->format{{ (builder_column.getter|classify)|php_name }}Value($rowData);
+            } else {
+                $data = $this->getValueForCell('{{ builder_column.getter }}', $rowData);
+            }
             $sheet->setCellValueByColumnAndRow({{ column }}, $row, $data);
             {% set column = column + 1 %}
           {%- endfor %}

--- a/Resources/templates/CommonAdmin/ExcelAction/ExcelBuilderAction.php.twig
+++ b/Resources/templates/CommonAdmin/ExcelAction/ExcelBuilderAction.php.twig
@@ -96,7 +96,7 @@ class ExcelController extends ListController
 
         // Convert DateTime object to given format
         if ($data instanceof \DateTime) {
-            $data = $data->format('d-m-Y H:i:s');
+            $data = $data->format('{{ builder.dateTimeFormat }}');
         }
 
         return $data;

--- a/Resources/templates/CommonAdmin/ExcelAction/ExcelBuilderAction.php.twig
+++ b/Resources/templates/CommonAdmin/ExcelAction/ExcelBuilderAction.php.twig
@@ -74,6 +74,35 @@ class ExcelController extends ListController
     }
 
     /**
+     * Gets the value from the given field that will be place at an Excel cell
+     *
+     * @param string $field   The name of the field to extract the value
+     * @param mixed  $rowData The main entity object
+     *
+     * @return $data The data to place on the respective Excel cell
+     */
+    protected function getValueForCell($field, $rowData)
+    {
+        $getter = $field;
+        $data = $rowData;
+        // Retrieve relations
+        while (($pos = strpos($getter, '.')) > 0) {
+            $tempGetter = 'get'.ucfirst(substr($getter, 0, $pos));
+            $getter = substr($getter, $pos + 1);
+            $data = $data->$tempGetter();
+        }
+        $getter = 'get'.ucfirst($getter);
+        $data = $data->$getter();
+
+        // Convert DateTime object to given format
+        if ($data instanceof \DateTime) {
+            $data = $data->format('d-m-Y H:i:s');
+        }
+
+        return $data;
+    }
+
+    /**
      * Fills the Excel spreadsheet with data
      */
     protected function createExcelData(\PhpExcel_Worksheet $sheet)
@@ -81,26 +110,14 @@ class ExcelController extends ListController
         $row = 2;
         $results = $this->getResults();
         foreach($results as $rowData) {
-        {% set colNum = 0 %}
-        {% for column in builder.columns %}
-            // Retrieve relations
-            $getter = '{{ column.getter }}';
-            $data = $rowData;
-            while (($pos = strpos($getter, '.')) > 0) {
-                $tempGetter = 'get' . ucfirst(substr($getter, 0, $pos));
-                $getter = substr($getter, $pos + 1);
-                $data = $data->$tempGetter();
-            }
-            $getter = 'get' . ucfirst($getter);
-            $data = $data->$getter();
+          {%- set column = 0 -%}
+          {%- for builder_column in builder.columns %}
 
-            // Convert DateTime object to given format
-            if ($data instanceof \DateTime){
-                $data = $data->format('{{ builder.dateTimeFormat }}');
-            }
-            $sheet->setCellValueByColumnAndRow({{ colNum }}, $row, $data);
-        {% set colNum = colNum + 1 %}
-        {% endfor %}
+            $data = $this->getValueForCell('{{ builder_column.getter }}', $rowData);
+            $sheet->setCellValueByColumnAndRow({{ column }}, $row, $data);
+            {% set column = column + 1 %}
+          {%- endfor %}
+
             $row++;
         }
     }


### PR DESCRIPTION
Added  a `getValueForCell` protected function so that extending the values format for the cells will be easier.

For instance if we need to format the value of a field which we know it's a currency, we can easily extends this method and add those special cases. E.g.:

``` php
protected function getValueForCell($field, $rowData)
{
    switch($field) {
        case 'price':
        case 'productionCost':
            $getter = 'get'.ucfirst($field);
            $data = number_format($rowData->$getter(), 2, ',', '.');
            break;
        default:
            $data = parent::getValueForCell($field, $rowData);
            break;
    }
    return $data;
}
```

I don't know if this is the best example, but this can also be used to render boolean field with some text other than `TRUE/FALSE`.
