### PR TITLE
fix DoctrineODMFieldGuesser::getModelPrimaryKeyName()

### DIFF
--- a/Guesser/DoctrineODMFieldGuesser.php
+++ b/Guesser/DoctrineODMFieldGuesser.php
@@ -232,6 +232,6 @@ class DoctrineODMFieldGuesser extends ContainerAware
      */
     public function getModelPrimaryKeyName($class = null)
     {
-        return $this->getMetadatas($class)->getIdentifier();
+        return $this->getMetadatas($class)->getIdentifier()[0];
     }
 }


### PR DESCRIPTION
that method returned  an array instead of string what threw an exception in the templates (resulting from an "array to string conversion"-notice)
