### PR TITLE
Update installation-via-composer.md

### DIFF
--- a/Resources/doc/installation/installation-via-composer.md
+++ b/Resources/doc/installation/installation-via-composer.md
@@ -10,23 +10,17 @@
 Add Admingenerator to your `composer.json`:
 
 #### 1.1   Symfony 2.3.X
-```json
-"require": {
-    "cedriclombardot/admingenerator-generator-bundle": "2.3.*@dev"
-},
+```sh
+composer require cedriclombardot/admingenerator-generator-bundle:~2.3
 ```
 
 #### 1.1   Symfony 2.2.X
-```json
-"require": {
-    "cedriclombardot/admingenerator-generator-bundle": "2.2.*@dev"
-},
+```sh
+composer require cedriclombardot/admingenerator-generator-bundle:~2.2
 ```
 #### 1.1   Symfony 2.1.X
-```json
-"require": {
-   "cedriclombardot/admingenerator-generator-bundle": "2.1.*@dev"
-},
+```sh
+composer require cedriclombardot/admingenerator-generator-bundle:~2.1
 ```
 
 ### 1.2 Checkin your composer 


### PR DESCRIPTION
Updated installation instructions via composer to use the `composer require` command without specifying a version.
This is the new recommended way of providing this information and it leads to composer picking the proper version constraint (i.e ~1.2), updating the `composer.json` and running install, all in one command.