### PR TITLE
Fixed PHPDoc namespace where missing \ at the start

### DIFF
--- a/Resources/templates/Doctrine/ActionsBuilderAction.php.twig
+++ b/Resources/templates/Doctrine/ActionsBuilderAction.php.twig
@@ -2,10 +2,10 @@
 
 {% block getObject %}
     /**
-     * Get object {{ model }} with identifier $pk
+     * Get object \{{ model }} with identifier $pk
      *
      * @param mixed $pk
-     * @return {{ model }}
+     * @return \{{ model }}
      */
     protected function getObject($pk)
     {

--- a/Resources/templates/Doctrine/EditBuilderAction.php.twig
+++ b/Resources/templates/Doctrine/EditBuilderAction.php.twig
@@ -7,10 +7,10 @@ use Doctrine\ORM\OptimisticLockException;
 
 {% block getObject -%}
     /**
-     * Get object {{ model }} with identifier $pk
+     * Get object \{{ model }} with identifier $pk
      *
      * @param mixed $pk
-     * @return {{ model }}
+     * @return \{{ model }}
      */
     protected function getObject($pk)
     {

--- a/Resources/templates/Doctrine/ShowBuilderAction.php.twig
+++ b/Resources/templates/Doctrine/ShowBuilderAction.php.twig
@@ -1,10 +1,10 @@
 {% extends '../CommonAdmin/ShowAction/ShowBuilderAction.php.twig' %}
 {% block getObject -%}
     /**
-     * Get object {{ model }} with identifier $pk
+     * Get object \{{ model }} with identifier $pk
      *
      * @param mixed $pk
-     * @return {{ model }}
+     * @return \{{ model }}
      */
     protected function getObject($pk)
     {

--- a/Resources/templates/DoctrineODM/ActionsBuilderAction.php.twig
+++ b/Resources/templates/DoctrineODM/ActionsBuilderAction.php.twig
@@ -3,10 +3,10 @@
 {% block getObject %}
 
     /**
-     * Get object {{ model }} with identifier $pk
+     * Get object \{{ model }} with identifier $pk
      *
      * @param mixed $pk
-     * @return {{ model }}
+     * @return \{{ model }}
      */
     protected function getObject($pk)
     {

--- a/Resources/templates/DoctrineODM/EditBuilderAction.php.twig
+++ b/Resources/templates/DoctrineODM/EditBuilderAction.php.twig
@@ -7,10 +7,10 @@ use Doctrine\ODM\MongoDB\LockException;
 
 {% block getObject -%}
     /**
-     * Get object {{ model }} with identifier $pk
+     * Get object \{{ model }} with identifier $pk
      *
      * @param mixed $pk
-     * @return {{ model }}
+     * @return \{{ model }}
      */
     protected function getObject($pk)
     {

--- a/Resources/templates/DoctrineODM/ShowBuilderAction.php.twig
+++ b/Resources/templates/DoctrineODM/ShowBuilderAction.php.twig
@@ -2,10 +2,10 @@
 
 {% block getObject -%}
     /**
-     * Get object {{ model }} with identifier $pk
+     * Get object \{{ model }} with identifier $pk
      *
      * @param mixed $pk
-     * @return {{ model }}
+     * @return \{{ model }}
      */
     protected function getObject($pk)
     {


### PR DESCRIPTION
There is a \ missing at the start of PHPDoc in getObject method. That cause some very minor issues when you Inspect Code for issues.
