### PR TITLE
add note about adding empty directories to git

### DIFF
--- a/Resources/doc/cookbook/extending-generator-templates.md
+++ b/Resources/doc/cookbook/extending-generator-templates.md
@@ -16,7 +16,7 @@ admingenerator_generator:
 
 2. Keep in mind that you will at least need **one dir** in the previous specified template directory, namely of the DBAL layer used, so one of [Doctrine, DoctrineODM, Propel]. 
 Without this directory, the specified template directory will not be used for extending/overwriting any of the templates, even in the CommonAdmin dir. 
-Note: If you are using git and your directory is empty you will [need to add a .gitignore file to add this directory to git](https://git.wiki.kernel.org/index.php/GitFaq#Can_I_add_empty_directories.3F).
+Note: If you are using git and your directory is empty you will [need to add least one file to add this directory to git](https://git.wiki.kernel.org/index.php/GitFaq#Can_I_add_empty_directories.3F). It's convention to add a .gitkeep file.
 
 3. Be free to extend/overwrite any template in the Resources/templates dir of the AdminGenerator!
 

--- a/Resources/doc/cookbook/extending-generator-templates.md
+++ b/Resources/doc/cookbook/extending-generator-templates.md
@@ -16,6 +16,7 @@ admingenerator_generator:
 
 2. Keep in mind that you will at least need **one dir** in the previous specified template directory, namely of the DBAL layer used, so one of [Doctrine, DoctrineODM, Propel]. 
 Without this directory, the specified template directory will not be used for extending/overwriting any of the templates, even in the CommonAdmin dir. 
+Note: If you are using git and your directory is empty you will [need to add a .gitignore file to add this directory to git](https://git.wiki.kernel.org/index.php/GitFaq#Can_I_add_empty_directories.3F).
 
 3. Be free to extend/overwrite any template in the Resources/templates dir of the AdminGenerator!
 


### PR DESCRIPTION
Git won't add empty directories but to take template override into account there is at least one of [Doctrine, DoctrineODM, Propel] needed.
also see: https://github.com/symfony2admingenerator/AdmingeneratorGeneratorBundle/issues/789